### PR TITLE
【イベント】画面情報を整理（画面遷移図を用意）#13

### DIFF
--- a/docs/arch/view/event/イベント関連画面.md
+++ b/docs/arch/view/event/イベント関連画面.md
@@ -1,0 +1,33 @@
+# イベントに関連する画面情報
+## 画面一覧
+- 新規作成
+  - 新規にイベントを作成するための簡単なフォーム 
+- イベント一覧画面
+  - イベントの一覧を確認する
+- 詳細
+  - イベントの情報を記載、間取りの確認や、当日参加者用ページへのリンクを提供
+- 間取り編集
+  - 間取りのエディタのようなもの
+- イベント編集
+  - イベントに関するメタ情報を保存
+
+## 画面遷移図
+```mermaid
+graph TD;
+		dash[["ダッシュボード"]];
+		eventList["イベント一覧"];
+		eventNew["イベント新規作成"];
+		eventView["イベント詳細"];
+		roomEdit["間取り編集"];
+		eventEdit["イベント編集"];
+		onTheDay[["当日ページ"]];
+		
+		dash --> eventNew;
+		dash --> eventList;
+		eventNew --> eventView;
+		eventList --> eventView;
+		eventView --> roomEdit ---> eventView;
+		eventView --> eventEdit --> eventView;
+		eventView ----> onTheDay;
+		eventView --> |"コピー作成"| eventView;
+```


### PR DESCRIPTION
以下の内容をfor-moku/docs内に入れました。

内容：
- イベントに関連する画面情報を整理
- 個別画面がどう遷移するのかを整理

画面の一覧情報に抜けがないのか、画面の遷移が問題ないのかの確認をお願いします。