### PR TITLE
【イベント】【詳細】何を出すべきなのかのリストアップ #33

### DIFF
--- a/docs/arch/view/event/イベント詳細画面.md
+++ b/docs/arch/view/event/イベント詳細画面.md
@@ -1,0 +1,46 @@
+# イベント詳細画面
+- 参加者がイベントの情報を確認できる
+- 管理者がイベントの情報を確認できる
+- 管理者が間取りを編集するかどうかを決められる
+- 管理者がイベント情報を編集するかどうかを決める
+
+# 参考ページ
+https://pg-beginner-mtg.connpass.com/event/356358/
+
+# 表示項目
+## 確実にいるもの（こっちが重要）
+- イベント名
+- 当日リンク
+- イベントの場所
+- 開始日
+- 終了日
+- イベントメモ
+- イベント詳細リンク
+
+## 要議論（個人的には欲しいけど）
+- 管理しているユーザグループ→いる？
+- 申し込みボタン？
+- ユーザが残すメモ
+- お気に入り機能
+- ユーザグループへの遷移
+
+# 画面遷移図（参考）
+```mermaid
+graph TD;
+		dash[["ダッシュボード"]];
+		eventList["イベント一覧"];
+		eventNew["イベント新規作成"];
+		eventView["イベント詳細"];
+		roomEdit["間取り編集"];
+		eventEdit["イベント編集"];
+		onTheDay[["当日ページ"]]
+		
+		dash --> eventNew
+		dash --> eventList
+		eventNew --> eventView
+		eventList --> eventView
+		eventView --> roomEdit ---> eventView;
+		eventView --> eventEdit --> eventView;
+		eventView ----> onTheDay
+		eventView --> |"コピー作成"| eventView
+```


### PR DESCRIPTION
イベント詳細画面を決めるにあたって議論しておきたい。
今回は必ず必要なもののみを表示し、おまけでつけたい機能については基本後回しでOK「