### PR TITLE
【共通】認証関連の問題の解決 #37

### DIFF
--- a/front/src/components/organisms/TopNav.tsx
+++ b/front/src/components/organisms/TopNav.tsx
@@ -7,8 +7,13 @@ import {
   DropdownMenuTrigger,
 } from "@/components/atoms/shadcn/dropdown-menu"
 import { LogOut, Settings, User } from "lucide-react"
+import { auth, signOut } from "@/lib/auth/auth"
 
-export function TopNav() {
+export async function TopNav() {
+  const session = await auth();
+
+  if (!session?.user) return null
+
   return (
     <nav className="fixed inset-x-0 top-0 z-50 bg-sidebar border-b">
       <div className="flex items-center justify-between h-14 px-8">
@@ -17,29 +22,40 @@ export function TopNav() {
             <h1 className="text-2xl font-bold">forもく</h1>
           </Link>
         </div>
-        <DropdownMenu>
-          <DropdownMenuTrigger className="flex items-center gap-2 text-sm">
-            YasunariIguchi
-            <Avatar>
-              <AvatarImage src="https://avatars.githubusercontent.com/u/39820920" />
-              <AvatarFallback>CN</AvatarFallback>
-            </Avatar>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent>
-            <DropdownMenuItem>
-              <User />
-              アカウント
-            </DropdownMenuItem>
-            <DropdownMenuItem>
-              <Settings />
-              設定
-            </DropdownMenuItem>
-            <DropdownMenuItem variant="destructive">
-              <LogOut />
-              ログアウト
-            </DropdownMenuItem>
-          </DropdownMenuContent>
-        </DropdownMenu>
+        <div className="flex items-center gap-2 text-sm">
+          {session.user.email}
+          <DropdownMenu>
+            <DropdownMenuTrigger>
+              <Avatar>
+                <AvatarImage src={`${session.user.image}`} alt="User Avatar"/>
+                <AvatarFallback>CN</AvatarFallback>
+              </Avatar>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent className="min-w-[7rem] shadow-none">
+              <DropdownMenuItem>
+                <User />
+                アカウント
+              </DropdownMenuItem>
+              <DropdownMenuItem>
+                <Settings />
+                設定
+              </DropdownMenuItem>
+              <form
+                action={async () => {
+                  "use server"
+                  await signOut()
+                }}
+              >
+                <button type="submit" className="w-full">
+                  <DropdownMenuItem variant="destructive">
+                    <LogOut />
+                    ログアウト
+                  </DropdownMenuItem>
+                </button>
+              </form>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </div>
       </div>
     </nav>
   )

--- a/front/src/components/organisms/TopNav.tsx
+++ b/front/src/components/organisms/TopNav.tsx
@@ -28,7 +28,7 @@ export async function TopNav() {
             <DropdownMenuTrigger>
               <Avatar>
                 <AvatarImage src={`${session.user.image}`} alt="User Avatar"/>
-                <AvatarFallback>CN</AvatarFallback>
+                <AvatarFallback><User /></AvatarFallback>
               </Avatar>
             </DropdownMenuTrigger>
             <DropdownMenuContent className="min-w-[7rem] shadow-none">

--- a/front/src/lib/auth/auth.ts
+++ b/front/src/lib/auth/auth.ts
@@ -14,8 +14,8 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
   callbacks: {
     authorized({ request, auth }) {
       const { pathname } = request.nextUrl
-      if (pathname === "/sandbox") return true // ここでログインパスを制御できます。
-      // if (pathname === "/sandbox2") return !!auth
+      if (pathname === "/sandbox") return true
+
       return !!auth
     },
     async session({ session, token }) {

--- a/front/src/lib/auth/auth.ts
+++ b/front/src/lib/auth/auth.ts
@@ -16,7 +16,7 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
       const { pathname } = request.nextUrl
       if (pathname === "/sandbox") return true // ここでログインパスを制御できます。
       // if (pathname === "/sandbox2") return !!auth
-      return true
+      return !!auth
     },
     async session({ session, token }) {
       if (token?.accessToken) session.accessToken = token.accessToken
@@ -24,7 +24,6 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
       return session
     },
   },
-  experimental: { enableWebAuthn: true },
 })
 
 declare module "next-auth" {

--- a/front/src/middleware.ts
+++ b/front/src/middleware.ts
@@ -2,5 +2,5 @@ export { auth as middleware } from "@/lib/auth/auth"
 
 // Read more: https://nextjs.org/docs/app/building-your-application/routing/middleware#matcher
 export const config = {
-    matcher: ["/((?!api|_next/static|_next/image|favicon.ico).*)"],
+    matcher: ["/((?!api|_next/static|_next/image|favicon.ico|auth).*)"],
   }


### PR DESCRIPTION
・auth.tsのcallbacksを変更、middlewareが認証関連のパスでコールされないようにする
　→こうすることでauthのパスを含まないすべてのページでログインが求められる
・dropdown menuからログアウトできるようにロジックを追加
・ログインしたユーザの情報（アバターとメアド）がヘッダーに表示される