### PR TITLE
【イベント】【間取り編集】ツールの仕様決めやサンプル画面の作成などの下準備 #44 (feature/#44-1)

### DIFF
--- a/front/src/app/event/venueedit/sample/page.tsx
+++ b/front/src/app/event/venueedit/sample/page.tsx
@@ -1,0 +1,7 @@
+import VenueEditorTemplate from "@/components/templates/event/venueedit/VenueEditorTemplate"
+
+export default async function Events() {
+  return (
+    <VenueEditorTemplate />
+  );
+}

--- a/front/src/components/templates/event/venueedit/VenueActionHeader.tsx
+++ b/front/src/components/templates/event/venueedit/VenueActionHeader.tsx
@@ -1,0 +1,34 @@
+export default function VenueActionHeader() {
+  return (
+    <div className="flex flex-col justify-center items-center border border-gray-900 mx-2 rounded-lg p-4 m-4 gap-4">
+      <div className="items-center justify-between w-full grid grid-cols-4 lg:grid-cols-4 xl:grid-cols-2">
+        <div className="col-span-3 xl:col-span-1 flex justify-between mx-2">
+          <div className="flex space-x-2">
+            <button className="px-4 py-2 bg-red-500 text-white rounded hover:bg-red-600">
+              元に戻す
+            </button>
+            <button className="px-4 py-2 bg-red-500 text-white rounded hover:bg-red-600">
+              キャンバスサイズ変更
+            </button>
+          </div>
+          <div className="flex space-x-2">
+            <button className="px-4 py-2 bg-gray-900 text-white rounded hover:bg-gray-600">
+              縮小
+            </button>
+            <button className="px-4 py-2 bg-gray-900 text-white rounded hover:bg-gray-600">
+              拡大
+            </button>
+          </div>
+        </div>
+        <div className="col-span-1 flex justify-end space-x-2">
+          <button className="px-4 py-2 bg-red-500 text-white rounded hover:bg-red-600">
+            取り消し
+          </button>
+          <button className="px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600">
+            保存
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+} 

--- a/front/src/components/templates/event/venueedit/VenueEditor.tsx
+++ b/front/src/components/templates/event/venueedit/VenueEditor.tsx
@@ -1,0 +1,66 @@
+'use client'
+
+import { useCanvasDraw } from '@/hooks/venue/useCanvasDraw'
+
+interface VenueEditorProps {
+  selectedTool: string
+  n_pixel?: number
+  zoom?: number
+}
+
+const canvasStyleFactory = (zoom: number, CANVAS_BASE: number) : React.CSSProperties=> {
+  return {
+    transform: `scale(${zoom / 100})`,
+    transformOrigin: zoom < 100 ? 'center center' : 'left top',
+    transition: 'transform 0.2s ease-in-out',
+    position: 'relative',
+    display: 'inline-block',
+    transformBox: 'fill-box',
+    width: `${CANVAS_BASE}px`,
+    height: `${CANVAS_BASE}px`,
+  }
+}
+
+export default function VenueEditor({ selectedTool, n_pixel = 8, zoom = 160 }: VenueEditorProps) {
+
+  // キャンバスに関連するフック（いわゆるカスタムフック）
+  const { canvasRef, CANVAS_BASE} = useCanvasDraw({ n_pixel }) 
+  
+  const handleCanvasMouseMove = (e: React.MouseEvent<HTMLCanvasElement>) => {
+    // マウス移動時の処理
+  }
+
+  const handleCanvasMouseDown = (e: React.MouseEvent<HTMLCanvasElement>) => {
+    // マウスダウン時の処理
+  }
+
+  const handleCanvasMouseUp = (e: React.MouseEvent<HTMLCanvasElement>) => {
+    // マウスアップ時の処理
+  }
+
+  return (
+    <div className="flex flex-col items-center border border-gray-900 rounded-lg p-4 overflow-x-auto">
+      <div>
+        <span className="text-lg font-semibold">キャンバス</span>
+      </div>
+
+      <div style={{ maxWidth: `${CANVAS_BASE}px`, maxHeight: `${CANVAS_BASE + 0}px` }}>
+        <div
+          className="flex"
+          style={canvasStyleFactory(zoom, CANVAS_BASE)}
+        >
+          <canvas
+            ref={canvasRef}
+            onMouseMove={handleCanvasMouseMove}
+            onMouseDown={handleCanvasMouseDown}
+            onMouseUp={handleCanvasMouseUp}
+            style={{
+              width: `${CANVAS_BASE}px`,
+              height: `${CANVAS_BASE}px`,
+            }}
+          />
+        </div>
+      </div>
+    </div>
+  )
+} 

--- a/front/src/components/templates/event/venueedit/VenueEditorTemplate.tsx
+++ b/front/src/components/templates/event/venueedit/VenueEditorTemplate.tsx
@@ -1,0 +1,39 @@
+'use client'
+
+import { useState } from 'react'
+import VenueActionHeader from "./VenueActionHeader"
+import VenueEditor from "./VenueEditor"
+import VenueToolSubMenu from "./VenueToolSubMenu"
+import VenueToolSelectionMenu from "./VenueToolSelectionMenu"
+
+export default function VenueEditorTemplate() {
+  const [selectedTool, setSelectedTool] = useState<string>('')
+  const [zoom] = useState(100)
+  const [n_pixel] = useState(16)
+
+  return (
+    <div className="pb-10">
+      <VenueActionHeader />
+      <div className="p-5">
+        <div className="grid grid-cols-1 lg:grid-cols-8 xl:grid-cols-12 gap-4">
+          <div className="col-span-1 md:col-span-1 lg:col-span-6 xl:col-span-6">
+            <VenueEditor 
+              selectedTool={selectedTool} 
+              n_pixel={n_pixel}
+              zoom={zoom}
+            />
+          </div>
+          <div className="col-span-1 md:col-span-1 lg:col-span-2 xl:col-span-2">
+            <VenueToolSubMenu selectedTool={selectedTool} />
+          </div>
+          <div className="col-span-1 md:col-span-1 lg:col-span-8 xl:col-span-4">
+            <VenueToolSelectionMenu 
+              selectedTool={selectedTool}
+              onToolSelect={setSelectedTool}
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/front/src/components/templates/event/venueedit/VenueToolSelectionMenu.tsx
+++ b/front/src/components/templates/event/venueedit/VenueToolSelectionMenu.tsx
@@ -1,0 +1,96 @@
+import { useState } from 'react'
+
+interface VenueToolSelectionMenuProps {
+  selectedTool: string
+  onToolSelect: (toolName: string) => void
+}
+
+export default function VenueToolSelectionMenu({ selectedTool, onToolSelect }: VenueToolSelectionMenuProps) {
+  return (
+    <div className="h-full w-full flex flex-col justify-center items-center border border-gray-900 rounded-lg">
+      <div className="h-full w-full flex flex-col">
+        <div className="flex-none p-4">
+          <span className="text-lg font-semibold">ツール選択メニュー</span>
+        </div>
+        <div className="flex-1 overflow-y-auto p-4">
+          <div className="grid grid-cols-6 xl:grid-cols-1 gap-2">
+            <div className="col-span-1 grid grid-cols-1 xl:grid-cols-2 grid-rows-2 xl:grid-rows-1 gap-2">
+              <button 
+                className="w-full p-2 bg-gray-900 text-white rounded hover:bg-gray-600"
+                onClick={() => onToolSelect('ピクセル塗りつぶし')}
+              >
+                ピクセル塗りつぶし
+              </button>
+              <button 
+                className="w-full p-2 bg-gray-900 text-white rounded hover:bg-gray-600"
+                onClick={() => onToolSelect('ピクセル消去')}
+              >
+                ピクセル消去
+              </button>
+            </div>
+
+            <div className="col-span-1 grid grid-cols-1 xl:grid-cols-2 grid-rows-2 xl:grid-rows-1 gap-2">
+              <button 
+                className="w-full p-2 bg-gray-900 text-white rounded hover:bg-gray-600"
+                onClick={() => onToolSelect('丸オブジェクト配置')}
+              >
+                丸オブジェクト配置
+              </button>
+              <button 
+                className="w-full p-2 bg-gray-900 text-white rounded hover:bg-gray-600"
+                onClick={() => onToolSelect('丸オブジェクト消去')}
+              >
+                丸オブジェクト消去
+              </button>
+            </div>
+
+            <div className="col-span-1 grid grid-cols-1 xl:grid-cols-2 grid-rows-2 xl:grid-rows-1 gap-2">
+              <button 
+                className="w-full p-2 bg-gray-900 text-white rounded hover:bg-gray-600"
+                onClick={() => onToolSelect('任意オブジェクト配置')}
+              >
+                任意オブジェクト配置
+              </button>
+              <button 
+                className="w-full p-2 bg-gray-900 text-white rounded hover:bg-gray-600"
+                onClick={() => onToolSelect('任意オブジェクト消去')}
+              >
+                任意オブジェクト消去
+              </button>
+            </div>
+
+            <div className="col-span-1 grid grid-cols-1 xl:grid-cols-2 grid-rows-2 xl:grid-rows-1 gap-2">
+              <button 
+                className="w-full p-2 bg-gray-900 text-white rounded hover:bg-gray-600"
+                onClick={() => onToolSelect('テキストボックス追加')}
+              >
+                テキストボックス追加
+              </button>
+              <button 
+                className="w-full p-2 bg-gray-900 text-white rounded hover:bg-gray-600"
+                onClick={() => onToolSelect('テキストボックス消去')}
+              >
+                テキストボックス消去
+              </button>
+            </div>
+
+            <div className="col-span-1 grid grid-cols-1 xl:grid-cols-2 grid-rows-2 xl:grid-rows-1 gap-2">
+              <button 
+                className="w-full p-2 bg-gray-900 text-white rounded hover:bg-gray-600"
+                onClick={() => onToolSelect('直線描画')}
+              >
+                直線描画
+              </button>
+              <button 
+                className="w-full p-2 bg-gray-900 text-white rounded hover:bg-gray-600"
+                onClick={() => onToolSelect('直線消去')}
+              >
+                直線消去
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+} 

--- a/front/src/components/templates/event/venueedit/VenueToolSubMenu.tsx
+++ b/front/src/components/templates/event/venueedit/VenueToolSubMenu.tsx
@@ -1,0 +1,20 @@
+interface VenueToolSubMenuProps {
+  selectedTool: string
+}
+
+export default function VenueToolSubMenu({ selectedTool }: VenueToolSubMenuProps) {
+  return (
+    <div className="h-full w-full flex flex-col justify-center items-center border border-gray-900 rounded-lg">
+      <div className="h-full w-full flex flex-col">
+        <div className="flex-none p-4">
+          <span className="text-lg font-semibold">サブメニュー</span>
+        </div>
+        <div className="flex-1 overflow-y-auto p-4">
+          <div className="p-2 bg-gray-100 rounded">
+            <span className="text-sm">現在のツール: {selectedTool || 'なし'}</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+} 

--- a/front/src/hooks/venue/useCanvasDraw.ts
+++ b/front/src/hooks/venue/useCanvasDraw.ts
@@ -1,0 +1,58 @@
+import { useRef, useEffect } from 'react'
+import { drawPatternCanvas, drawGrid } from '@/lib/event/venueedit/pattern'
+
+/**
+ * キャンバスの描画を管理するフックのProps
+ * @param n_pixel ピクセル数
+ */
+interface Props {
+  n_pixel?: number
+}
+
+/**
+ * キャンバスのサイズ(ひとまず固定とします)
+ */
+const CANVAS_BASE = 512;
+
+/**
+ * キャンバスの描画を管理するフック
+ * @param n_pixel ピクセル数
+ * @returns キャンバスの参照、キャンバスのサイズ、セルの座標を取得する関数
+ */
+export const useCanvasDraw = ({ n_pixel = 8 }: Props) => {
+  const canvasRef = useRef<HTMLCanvasElement>(null)
+  const CELL_SIZE = CANVAS_BASE / n_pixel
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+
+    // キャンバスのサイズを設定
+    canvas.width = CANVAS_BASE;
+    canvas.height = CANVAS_BASE;
+
+    // パターンの描画
+    drawPatternCanvas(ctx, n_pixel, CELL_SIZE);
+
+    // グリッドの描画
+    drawGrid(ctx, n_pixel, CELL_SIZE);
+
+  }, [n_pixel])
+
+  /**
+   * セルの座標を取得する関数
+   * @param x ピクセルのx座標
+   * @param y ピクセルのy座標
+   * @returns セルの座標
+   */
+  const getCellCoordinates = (x: number, y: number) => {
+    const cellX = Math.floor(x / CELL_SIZE);
+    const cellY = Math.floor(y / CELL_SIZE);
+    return { cellX, cellY };
+  }
+
+  return { canvasRef, CANVAS_BASE, getCellCoordinates };
+} 

--- a/front/src/lib/event/venueedit/pattern.ts
+++ b/front/src/lib/event/venueedit/pattern.ts
@@ -1,0 +1,62 @@
+/**
+ * グリッドを描画する
+ * @param ctx キャンバスのコンテキスト
+ * @param pixels ピクセル数
+ * @param cellSize セルサイズ
+ */
+export const drawGrid = (ctx: CanvasRenderingContext2D, pixels: number, cellSize: number) => {
+  const canvasBase = pixels * cellSize
+  ctx.strokeStyle = '#777777'
+  ctx.lineWidth = 1
+
+  // 縦線
+  for (let i = 1; i < pixels; i++) {
+    ctx.beginPath()
+    ctx.moveTo(i * cellSize, 0)
+    ctx.lineTo(i * cellSize, canvasBase)
+    ctx.stroke()
+  }
+
+  // 横線
+  for (let i = 1; i < pixels; i++) {
+    ctx.beginPath()
+    ctx.moveTo(0, i * cellSize)
+    ctx.lineTo(canvasBase, i * cellSize)
+    ctx.stroke()
+  }
+
+} 
+
+/**
+ * パターンを作成用のキャンバスを作成し、パターンでキャンバスを埋め尽くす
+ * @param ctx キャンバスのコンテキスト
+ * @param pixels ピクセル数
+ * @param cellSize セルサイズ
+ */
+export const drawPatternCanvas = (ctx: CanvasRenderingContext2D, pixels: number, cellSize: number) => {
+  const canvasBase = pixels * cellSize
+
+  // 白黒のチェックを作成用のキャンバスを作成
+  const patternCanvas = document.createElement('canvas')
+  patternCanvas.width = 8
+  patternCanvas.height = 8
+  const patternCtx = patternCanvas.getContext('2d')
+  if (patternCtx) {
+    // 白い背景
+    patternCtx.fillStyle = '#ffffff'
+    patternCtx.fillRect(0, 0, 8, 8)
+    // グレーのチェック
+    patternCtx.fillStyle = '#e0e0e0'
+    patternCtx.fillRect(0, 0, 4, 4)
+    patternCtx.fillRect(4, 4, 4, 4)
+  }
+  
+  // 白黒のチェックを作成用のキャンバスからパターンを作成
+  const pattern = ctx.createPattern(patternCanvas, 'repeat')
+
+  // パターンでキャンバスを埋め尽くす
+  if (pattern) {
+    ctx.fillStyle = pattern
+    ctx.fillRect(0, 0, canvasBase, canvasBase)
+  }
+} 


### PR DESCRIPTION
過去のプルリクを作り直したものです。

ざっくりと画面のレイアウトを決めています。
基本的なUIとして以下の4つのコンポーネントに分けています。
- 1.ピクセルエディタ
- 2.ツールごとのサブメニュー（選択しているツールとか、ピクセルの色とか、色を変えたりとか）
- 3.ツール選択コンポーネント
- 4.その他アクション（拡大縮小、あるいは保存）

以下のリンクから確認できるようにしています。
http://localhost:3000/event/venueedit/sample

また、stateが使えることを確認するため、選択済みツールが2.ツールごとのサブメニューからわかるようにしています。
エディタは別のテクスチャで埋めています。

以下、コミットメッセージからの抜粋です。
- ざっくりと機能決め(今後変更予定)
- レイアウトもついでに決める
- Canvas要素with透明グリッドの準備
- 選択済みツールについてStateを準備し、サブメニューから選択済みツールに関する状態を確認できるようにする。