### PR TITLE
【イベント】【間取り編集】キャンバスの拡大縮小 #57 機能実装

### DIFF
--- a/front/src/components/templates/event/venueedit/VenueActionHeader.tsx
+++ b/front/src/components/templates/event/venueedit/VenueActionHeader.tsx
@@ -1,4 +1,12 @@
-export default function VenueActionHeader() {
+import { ZoomIn, ZoomOut } from 'lucide-react'
+
+interface Props {
+  handleZoomIn: () => void
+  handleZoomOut: () => void
+}
+
+export default function VenueActionHeader({ handleZoomIn, handleZoomOut }: Readonly<Props>) {
+
   return (
     <div className="flex flex-col justify-center items-center border border-gray-900 mx-2 rounded-lg p-4 m-4 gap-4">
       <div className="items-center justify-between w-full grid grid-cols-4 lg:grid-cols-4 xl:grid-cols-2">
@@ -12,11 +20,19 @@ export default function VenueActionHeader() {
             </button>
           </div>
           <div className="flex space-x-2">
-            <button className="px-4 py-2 bg-gray-900 text-white rounded hover:bg-gray-600">
-              縮小
+            <button 
+              className="px-2 py-2 bg-gray-900 text-white rounded hover:bg-gray-600 flex items-center gap-2"
+              onClick={handleZoomOut}
+            >
+              <ZoomOut size={20} />
+              
             </button>
-            <button className="px-4 py-2 bg-gray-900 text-white rounded hover:bg-gray-600">
-              拡大
+            <button 
+              className="px-2 py-2 bg-gray-900 text-white rounded hover:bg-gray-600 flex items-center gap-2"
+              onClick={handleZoomIn}
+            >
+              <ZoomIn size={20} />
+              
             </button>
           </div>
         </div>

--- a/front/src/components/templates/event/venueedit/VenueEditor.tsx
+++ b/front/src/components/templates/event/venueedit/VenueEditor.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useCanvasDraw } from '@/hooks/venue/useCanvasDraw'
+import { cn } from '@/lib/shadcn/utils'
 
 interface VenueEditorProps {
   selectedTool: string
@@ -21,7 +22,7 @@ const canvasStyleFactory = (zoom: number, CANVAS_BASE: number) : React.CSSProper
   }
 }
 
-export default function VenueEditor({ selectedTool, n_pixel = 8, zoom = 160 }: VenueEditorProps) {
+export default function VenueEditor({ selectedTool, n_pixel = 8, zoom = 150 }: VenueEditorProps) {
 
   // キャンバスに関連するフック（いわゆるカスタムフック）
   const { canvasRef, CANVAS_BASE} = useCanvasDraw({ n_pixel }) 
@@ -39,10 +40,10 @@ export default function VenueEditor({ selectedTool, n_pixel = 8, zoom = 160 }: V
   }
 
   return (
-    <div className="flex flex-col items-center border border-gray-900 rounded-lg p-4 overflow-x-auto">
-      <div>
-        <span className="text-lg font-semibold">キャンバス</span>
-      </div>
+    <div className={cn(
+      "flex flex-col border border-gray-900 rounded-lg p-4 overflow-x-auto",
+      zoom <= 100 && "items-center"
+    )}>
 
       <div style={{ maxWidth: `${CANVAS_BASE}px`, maxHeight: `${CANVAS_BASE + 0}px` }}>
         <div

--- a/front/src/components/templates/event/venueedit/VenueEditorTemplate.tsx
+++ b/front/src/components/templates/event/venueedit/VenueEditorTemplate.tsx
@@ -5,15 +5,19 @@ import VenueActionHeader from "./VenueActionHeader"
 import VenueEditor from "./VenueEditor"
 import VenueToolSubMenu from "./VenueToolSubMenu"
 import VenueToolSelectionMenu from "./VenueToolSelectionMenu"
+import { useZoom } from '@/hooks/venue/useZoom'
 
 export default function VenueEditorTemplate() {
   const [selectedTool, setSelectedTool] = useState<string>('')
-  const [zoom] = useState(100)
+  const {zoom, handleZoomIn, handleZoomOut } = useZoom(100)
   const [n_pixel] = useState(16)
 
   return (
     <div className="pb-10">
-      <VenueActionHeader />
+      <VenueActionHeader 
+        handleZoomIn={handleZoomIn}
+        handleZoomOut={handleZoomOut}
+      />
       <div className="p-5">
         <div className="grid grid-cols-1 lg:grid-cols-8 xl:grid-cols-12 gap-4">
           <div className="col-span-1 md:col-span-1 lg:col-span-6 xl:col-span-6">

--- a/front/src/hooks/venue/useZoom.ts
+++ b/front/src/hooks/venue/useZoom.ts
@@ -1,0 +1,35 @@
+import { useState } from 'react'
+
+const ZOOM_LEVELS = [25, 50, 100, 200, 400] as const
+type ZoomLevel = typeof ZOOM_LEVELS[number]
+
+export const useZoom = (initialZoom: ZoomLevel = 100) => {
+  const [zoom, setZoom] = useState<ZoomLevel>(initialZoom)
+
+  const handleZoomIn = () => {
+    setZoom((prevZoom: ZoomLevel) => {
+      const currentIndex = ZOOM_LEVELS.indexOf(prevZoom)
+      if (currentIndex < ZOOM_LEVELS.length - 1) {
+        return ZOOM_LEVELS[currentIndex + 1]
+      }
+      return prevZoom
+    })
+  }
+
+  const handleZoomOut = () => {
+    setZoom((prevZoom: ZoomLevel) => {
+      const currentIndex = ZOOM_LEVELS.indexOf(prevZoom)
+      if (currentIndex > 0) {
+        return ZOOM_LEVELS[currentIndex - 1]
+      }
+      return prevZoom
+    })
+  }
+
+  return {
+    zoom,
+    setZoom,
+    handleZoomIn,
+    handleZoomOut,
+  }
+} 


### PR DESCRIPTION
 - 拡大縮小ができるように改良
 - 拡大縮小のボタンを変更
 - (x0.25, x0.5, x1, x2, x4)の間でのみ動くように修正
 
 ボタンを押すと拡大縮小できます。
 
 以下、検証URLです。
 http://localhost:3000/event/venueedit/sample
 
 
![image](https://github.com/user-attachments/assets/9ebc3a34-266a-4062-9f1f-4e0517aaab6c)
