### PR TITLE
【イベント】【間取り編集】ピクセルの上に丸オブジェクトを配置したり、消したりできるようにする #48

### DIFF
--- a/front/src/hooks/event/venueedit/tool/useCellEditableTool.ts
+++ b/front/src/hooks/event/venueedit/tool/useCellEditableTool.ts
@@ -7,7 +7,9 @@ interface Props {
   canvasRef: React.RefObject<HTMLCanvasElement | null>
   numPixel: number
   pixelColorState: (Color | null)[][]
+  circleColorState: (Color | null)[][]
   updatePixelState?: (x: number, y: number) => (Color | null)[][]
+  updateCircleState?: (x: number, y: number) => (Color | null)[][]
 }
 
 /**
@@ -22,14 +24,16 @@ export const useCellEditableTool = ({
   canvasRef, 
   numPixel, 
   pixelColorState,
-  updatePixelState 
+  circleColorState,
+  updatePixelState,
+  updateCircleState
 }: Props) => {
   const [isDrawing, setIsDrawing] = useState(false)
   const lastCellRef = useRef<{ x: number; y: number } | null>(null)
   const CELL_SIZE = CANVAS_BASE / numPixel
 
-  const syncToCanvas = useCallback((x: number, y: number, ctx: CanvasRenderingContext2D, state: (Color | null)[][]) => {
-    syncPixelStateToCanvas(ctx, x, y, CELL_SIZE, state)
+  const syncToCanvas = useCallback((x: number, y: number, ctx: CanvasRenderingContext2D, pixelState: (Color | null)[][], circleState: (Color | null)[][]) => {
+    syncPixelStateToCanvas(ctx, x, y, CELL_SIZE, pixelState, circleState)
   }, [CELL_SIZE])
 
   /**
@@ -47,9 +51,10 @@ export const useCellEditableTool = ({
 
     lastCellRef.current = { x: coords.cellX, y: coords.cellY }
     const newPixelColorState = updatePixelState ? updatePixelState(coords.cellX, coords.cellY) : pixelColorState
-    syncToCanvas(coords.cellX, coords.cellY, ctx, newPixelColorState)
+    const newCircleColorState = updateCircleState ? updateCircleState(coords.cellX, coords.cellY) : circleColorState
+    syncToCanvas(coords.cellX, coords.cellY, ctx, newPixelColorState, newCircleColorState)
 
-  }, [pixelColorState, updatePixelState])
+  }, [pixelColorState, updatePixelState, circleColorState, updateCircleState])
 
   /**
    * マウスを動かしている時
@@ -71,8 +76,9 @@ export const useCellEditableTool = ({
 
     lastCellRef.current = { x: coords.cellX, y: coords.cellY }
     const newPixelColorState = updatePixelState ? updatePixelState(coords.cellX, coords.cellY) : pixelColorState
-    syncToCanvas(coords.cellX, coords.cellY, ctx, newPixelColorState)
-  }, [isDrawing, pixelColorState, updatePixelState])
+    const newCircleColorState = updateCircleState ? updateCircleState(coords.cellX, coords.cellY) : circleColorState
+    syncToCanvas(coords.cellX, coords.cellY, ctx, newPixelColorState, newCircleColorState)
+  }, [isDrawing, pixelColorState, updatePixelState, circleColorState, updateCircleState])
 
   /**
    * マウスアップ（マウスボタンを離したとき）

--- a/front/src/hooks/event/venueedit/tool/useCircleDraw.ts
+++ b/front/src/hooks/event/venueedit/tool/useCircleDraw.ts
@@ -12,20 +12,20 @@ interface Props {
   circleColorState: (Color | null)[][]
 }
 
-export const usePixelDraw = ({ canvasRef, numPixel, selectedColor, setPixelColorState, pixelColorState, circleColorState }: Props) => {
-  const updatePixelState = useCallback((x: number, y: number) => {
-    const newState = [...pixelColorState]
+export const useCircleDraw = ({ canvasRef, numPixel, selectedColor, setCircleColorState, pixelColorState, circleColorState }: Props) => {
+  const updateCircleState = useCallback((x: number, y: number) => {
+    const newState = [...circleColorState]
     newState[y] = [...newState[y]]
     newState[y][x] = selectedColor
-    setPixelColorState(newState)
+    setCircleColorState(newState)
     return newState
-  }, [selectedColor, pixelColorState])
+  }, [selectedColor, circleColorState])
 
   return useCellEditableTool({
     canvasRef,
     numPixel,
     pixelColorState,
     circleColorState,
-    updatePixelState
+    updateCircleState
   })
 } 

--- a/front/src/hooks/event/venueedit/tool/useCircleErase.ts
+++ b/front/src/hooks/event/venueedit/tool/useCircleErase.ts
@@ -5,21 +5,20 @@ import { useCellEditableTool } from '@/hooks/event/venueedit/tool/useCellEditabl
 interface Props {
   canvasRef: React.RefObject<HTMLCanvasElement | null>
   numPixel: number
-  selectedColor: Color
   setPixelColorState: React.Dispatch<React.SetStateAction<(Color | null)[][]>>
   pixelColorState: (Color | null)[][]
   setCircleColorState: React.Dispatch<React.SetStateAction<(Color | null)[][]>>
   circleColorState: (Color | null)[][]
 }
 
-export const useCircleErase = ({ canvasRef, numPixel, selectedColor, setCircleColorState, pixelColorState, circleColorState }: Props) => {
+export const useCircleErase = ({ canvasRef, numPixel, setCircleColorState, pixelColorState, circleColorState }: Props) => {
   const updateCircleState = useCallback((x: number, y: number) => {
     const newState = [...circleColorState]
     newState[y] = [...newState[y]]
     newState[y][x] = null
     setCircleColorState(newState)
     return newState
-  }, [selectedColor, circleColorState])
+  }, [circleColorState])
 
   return useCellEditableTool({
     canvasRef,

--- a/front/src/hooks/event/venueedit/tool/useCircleErase.ts
+++ b/front/src/hooks/event/venueedit/tool/useCircleErase.ts
@@ -12,20 +12,20 @@ interface Props {
   circleColorState: (Color | null)[][]
 }
 
-export const usePixelDraw = ({ canvasRef, numPixel, selectedColor, setPixelColorState, pixelColorState, circleColorState }: Props) => {
-  const updatePixelState = useCallback((x: number, y: number) => {
-    const newState = [...pixelColorState]
+export const useCircleErase = ({ canvasRef, numPixel, selectedColor, setCircleColorState, pixelColorState, circleColorState }: Props) => {
+  const updateCircleState = useCallback((x: number, y: number) => {
+    const newState = [...circleColorState]
     newState[y] = [...newState[y]]
-    newState[y][x] = selectedColor
-    setPixelColorState(newState)
+    newState[y][x] = null
+    setCircleColorState(newState)
     return newState
-  }, [selectedColor, pixelColorState])
+  }, [selectedColor, circleColorState])
 
   return useCellEditableTool({
     canvasRef,
     numPixel,
     pixelColorState,
     circleColorState,
-    updatePixelState
+    updateCircleState
   })
 } 

--- a/front/src/hooks/event/venueedit/tool/usePixelErase.ts
+++ b/front/src/hooks/event/venueedit/tool/usePixelErase.ts
@@ -7,9 +7,11 @@ interface Props {
   numPixel: number
   setPixelColorState: React.Dispatch<React.SetStateAction<(Color | null)[][]>>
   pixelColorState: (Color | null)[][]
+  setCircleColorState: React.Dispatch<React.SetStateAction<(Color | null)[][]>>
+  circleColorState: (Color | null)[][]
 }
 
-export const usePixelErase = ({ canvasRef, numPixel, setPixelColorState, pixelColorState }: Props) => {
+export const usePixelErase = ({ canvasRef, numPixel, setPixelColorState, pixelColorState, setCircleColorState, circleColorState }: Props) => {
   const updatePixelState = useCallback((x: number, y: number) => {
     const newState = [...pixelColorState]
     newState[y] = [...newState[y]]
@@ -22,6 +24,7 @@ export const usePixelErase = ({ canvasRef, numPixel, setPixelColorState, pixelCo
     canvasRef,
     numPixel,
     pixelColorState,
+    circleColorState,
     updatePixelState
   })
 } 

--- a/front/src/hooks/event/venueedit/tool/useToolSelect.ts
+++ b/front/src/hooks/event/venueedit/tool/useToolSelect.ts
@@ -2,7 +2,9 @@ import { useCallback } from 'react'
 import { DRAWABLE_TOOLS, DrawableTool, VenueEditTool } from '@/types/tool'
 import { usePixelDraw } from '@/hooks/event/venueedit/tool/usePixelDraw'
 import { usePixelErase } from '@/hooks/event/venueedit/tool/usePixelErase'
+import { useCircleDraw } from '@/hooks/event/venueedit/tool/useCircleDraw'
 import { Color } from '@/types/color'
+import { useCircleErase } from '@/hooks/event/venueedit/tool/useCircleErase'
 
 interface Props {
   selectedTool: VenueEditTool
@@ -11,6 +13,8 @@ interface Props {
   numPixel: number
   pixelColorState: (Color | null)[][]
   setPixelColorState: React.Dispatch<React.SetStateAction<(Color | null)[][]>>
+  setCircleColorState: React.Dispatch<React.SetStateAction<(Color | null)[][]>>
+  circleColorState: (Color | null)[][]
 }
 
 type ToolHandlers = {
@@ -26,7 +30,9 @@ export const useToolSelect = ({
   canvasRef,
   numPixel,
   pixelColorState,
-  setPixelColorState
+  setPixelColorState,
+  setCircleColorState,
+  circleColorState
 }: Props) => {
   const canDraw = useCallback(() => {
     return DRAWABLE_TOOLS.includes(selectedTool as DrawableTool)
@@ -37,24 +43,49 @@ export const useToolSelect = ({
     numPixel,
     selectedColor,
     setPixelColorState,
-    pixelColorState
+    pixelColorState,
+    setCircleColorState,
+    circleColorState
   })
 
   const pixelErase = usePixelErase({
     canvasRef,
     numPixel,
     setPixelColorState,
-    pixelColorState
+    pixelColorState,
+    setCircleColorState,
+    circleColorState
+  })
+
+  const circleDraw = useCircleDraw({
+    canvasRef,
+    numPixel,
+    selectedColor,
+    setPixelColorState,
+    pixelColorState,
+    setCircleColorState,
+    circleColorState
+  })
+
+  const circleErase = useCircleErase({
+    canvasRef,
+    numPixel,
+    selectedColor,
+    setPixelColorState,
+    pixelColorState,
+    setCircleColorState,
+    circleColorState
   })
 
   const toolHandlers: Partial<Record<VenueEditTool, ToolHandlers>> = {
     'ピクセル塗りつぶし': pixelDraw,
-    'ピクセル消去': pixelErase
+    'ピクセル消去': pixelErase,
+    '丸オブジェクト配置': circleDraw,
+    '丸オブジェクト消去': circleErase,
   }
 
   const createHandler = (eventName: keyof ToolHandlers) => {
     return (e?: React.MouseEvent<HTMLCanvasElement>) => {
-      if (!canDraw()) return
       const handler = toolHandlers[selectedTool]
       if (handler) {
         if (eventName === 'handleMouseDown' || eventName === 'handleMouseMove') {

--- a/front/src/hooks/event/venueedit/useCanvasDraw.ts
+++ b/front/src/hooks/event/venueedit/useCanvasDraw.ts
@@ -32,7 +32,9 @@ export const useCanvasDraw = ({
   const [pixelColorState, setPixelColorState] = useState<(Color | null)[][]>(
     Array(numPixel).fill(null).map(() => Array(numPixel).fill(null))
   )
-
+  const [circleColorState, setCircleColorState] = useState<(Color | null)[][]>(
+    Array(numPixel).fill(null).map(() => Array(numPixel).fill(null))
+  )
   useEffect(() => {
     const canvas = canvasRef.current
     if (!canvas) return
@@ -41,6 +43,7 @@ export const useCanvasDraw = ({
     if (!ctx) return
 
     setPixelColorState(Array(numPixel).fill(null).map(() => Array(numPixel).fill(null)))
+    setCircleColorState(Array(numPixel).fill(null).map(() => Array(numPixel).fill(null)))
   }, [numPixel])
 
   const { canDraw, handleMouseDown, handleMouseMove, handleMouseUp, handleMouseLeave } = useToolSelect({
@@ -49,7 +52,9 @@ export const useCanvasDraw = ({
     canvasRef,
     numPixel,
     setPixelColorState,
-    pixelColorState
+    pixelColorState,
+    setCircleColorState,
+    circleColorState
   })
 
   return { 

--- a/front/src/lib/event/venueedit/canvasControl.ts
+++ b/front/src/lib/event/venueedit/canvasControl.ts
@@ -209,18 +209,44 @@ export const initializeCanvas = (
  */
 export const syncPixelStateToCanvas = (
   ctx: CanvasRenderingContext2D,
-  x: number,
-  y: number,
+  cellX: number,
+  cellY: number,
   cellSize: number,
-  pixelColorState: (Color | null)[][]
+  pixelColorState: (Color | null)[][],
+  circleColorState: (Color | null)[][]
 ) => {
-  const color = pixelColorState[y]?.[x]
+  const pixelColor = pixelColorState[cellY]?.[cellX]
+  const circleColor = circleColorState[cellY]?.[cellX]
+
   // セルを色で塗る
-  if (color != null) {
-    drawColoredCell(ctx, x, y, cellSize, color)
-    drawCellGrid(ctx, x, y, cellSize)
+  if (pixelColor != null) {
+    drawColoredCell(ctx, cellX, cellY, cellSize, pixelColor)
+    drawCellGrid(ctx, cellX, cellY, cellSize)
   } else {
-    drawPatternCell(ctx, x, y, cellSize)
-    drawCellGridThin(ctx, x, y, cellSize)
+    drawPatternCell(ctx, cellX, cellY, cellSize)
+    drawCellGridThin(ctx, cellX, cellY, cellSize)
   }
+  // 円を描画
+  if (circleColor != null) {
+    drawCircle(ctx, cellX, cellY, cellSize, circleColor)
+  }
+}
+
+/**
+ * 円を描画する
+ * @param ctx キャンバスのコンテキスト
+ * @param cellX x座標
+ * @param cellY y座標
+ * @param cellSize セルサイズ
+ * @param color 色
+ */
+export const drawCircle = (ctx: CanvasRenderingContext2D, cellX: number, cellY: number, cellSize: number, color: Color) => {
+  const centerX = cellX * cellSize + cellSize / 2
+  const centerY = cellY * cellSize + cellSize / 2
+  const radius = (cellSize / 2) * 0.8
+
+  ctx.fillStyle = color.toString()
+  ctx.beginPath()
+  ctx.arc(centerX, centerY, radius, 0, Math.PI * 2)
+  ctx.fill()
 } 


### PR DESCRIPTION
タイトルの通り、丸オブジェクトの配置&消去ができるようになりました。

以下、検証用URLです。
http://localhost:3000/event/venueedit/sample