### PR TITLE
【イベント】【間取り編集】テキストボックスを追加できるようにする #52

### DIFF
--- a/front/src/components/organisms/event/venueedit/palette/ColorAddButton.tsx
+++ b/front/src/components/organisms/event/venueedit/palette/ColorAddButton.tsx
@@ -16,8 +16,7 @@ export default function ColorAddButton({ onAddColor, disabled }: Readonly<ColorA
 
   const handleAddColor = () => {
     // ChromePickerから受け取る色は常にhex形式（#RRGGBB）
-    const hexColor = selectedColor as `#${string}`
-    onAddColor(color(hexColor))
+    onAddColor(selectedColor as Color)
     setIsOpen(false)
   }
 

--- a/front/src/components/organisms/event/venueedit/palette/ColorButton.tsx
+++ b/front/src/components/organisms/event/venueedit/palette/ColorButton.tsx
@@ -1,9 +1,10 @@
 'use client'
 
 import { X } from "lucide-react"
+import { Color } from "react-color"
 
 interface ColorButtonProps {
-  color: string
+  color: Color
   isSelected: boolean
   onClick: () => void
   onDelete: () => void
@@ -18,7 +19,7 @@ export default function ColorButton({ color, isSelected, onClick, onDelete }: Re
           aspect-square rounded cursor-pointer border-0 w-full
           ${isSelected ? 'ring-2 ring-blue-500 ring-offset-2' : ''}
         `}
-        style={{ backgroundColor: color }}
+        style={{ backgroundColor: color.toString() }}
         onClick={onClick}
       />
       <button

--- a/front/src/components/organisms/event/venueedit/palette/ColorPalette.tsx
+++ b/front/src/components/organisms/event/venueedit/palette/ColorPalette.tsx
@@ -23,7 +23,7 @@ export default function ColorPalette({
     <div className="grid grid-cols-12 lg:grid-cols-4 gap-2">
       {colors.map((color) => (
         <ColorButton
-          key={color}
+          key={color.toString()}
           color={color}
           isSelected={selectedColor === color}
           onClick={() => onColorSelect(color)}

--- a/front/src/components/organisms/event/venueedit/palette/ColorSingleSelector.tsx
+++ b/front/src/components/organisms/event/venueedit/palette/ColorSingleSelector.tsx
@@ -1,0 +1,73 @@
+'use client'
+
+import { Color, color } from '@/types/color'
+import ColorPickerDialog from './ColorPickerDialog'
+import { useState } from 'react'
+
+interface ColorSingleSelectorProps {
+  selectedColor: Color
+  selectedColorBackGround: Color
+  setSelectedColor: (color: Color) => void
+  setSelectedColorBackGround: (color: Color) => void
+}
+
+export default function ColorSingleSelector({
+  selectedColor,
+  selectedColorBackGround,  
+  setSelectedColor,
+  setSelectedColorBackGround,
+}: Readonly<ColorSingleSelectorProps>) {
+  const [isTextColorOpen, setIsTextColorOpen] = useState(false)
+  const [isBackgroundColorOpen, setIsBackgroundColorOpen] = useState(false)
+
+  const handleTextColorChange = (hex: string) => {
+    setSelectedColor(hex as Color)
+  }
+
+  const handleBackgroundColorChange = (hex: string) => {
+    setSelectedColorBackGround(hex as Color)
+  }
+
+  return (
+    <>
+      <div className="grid grid-cols-12 lg:grid-cols-2 gap-2">
+        <div className="col-span-1">
+          <span>テキスト色</span>
+        </div>
+        <div className="col-span-1">
+          <button
+            type="button"
+            className="w-24 h-6 rounded border border-gray-300 shadow-sm"
+            style={{ backgroundColor: selectedColor.toString() }}
+            onClick={() => setIsTextColorOpen(true)}
+          />
+        </div>
+        <div className="col-span-1">
+          <span>背景色</span>
+        </div>
+        <div className="col-span-1">
+          <button
+            type="button"
+            className="w-24 h-6 rounded border border-gray-300 shadow-sm"
+            style={{ backgroundColor: selectedColorBackGround.toString() }}
+            onClick={() => setIsBackgroundColorOpen(true)}
+          />
+        </div>
+      </div>
+      <ColorPickerDialog
+        isOpen={isTextColorOpen}
+        onOpenChange={setIsTextColorOpen}
+        color={selectedColor.toString()}
+        onColorChange={handleTextColorChange}
+        onAdd={() => setIsTextColorOpen(false)}
+      />
+      <ColorPickerDialog
+        isOpen={isBackgroundColorOpen}
+        onOpenChange={setIsBackgroundColorOpen}
+        color={selectedColorBackGround.toString()}
+        onColorChange={handleBackgroundColorChange}
+        onAdd={() => setIsBackgroundColorOpen(false)}
+      />
+    </>
+  )
+} 

--- a/front/src/components/organisms/event/venueedit/text/TextDialog.tsx
+++ b/front/src/components/organisms/event/venueedit/text/TextDialog.tsx
@@ -1,0 +1,59 @@
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from "@/components/atoms/shadcn/dialog"
+import { Button } from "@/components/atoms/shadcn/button"
+import { useEffect, useState } from "react"
+interface Props {
+  isOpen: boolean
+  onOpenChange: (open: boolean) => void
+  onTextChange: (text: string) => void
+  onAdd: () => void
+}
+
+export default function TextDialog({ isOpen, onOpenChange, onTextChange, onAdd}: Readonly<Props>) {
+  const [isChanged, setIsChanged] = useState(false)
+  
+  useEffect(() => {
+    setIsChanged(false)
+    onTextChange('')
+  }, [isOpen])
+  
+  const formAction = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault()
+    if (isChanged) {
+      onAdd()
+    }
+    onOpenChange(false)
+  }
+
+  const changeText = (text: string) => {
+    onTextChange(text)
+    setIsChanged(true)
+  }
+
+  return (
+    <Dialog open={isOpen} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[300px]">
+        <form onSubmit={formAction}>
+          <DialogHeader>
+            <DialogTitle>テキストを入力</DialogTitle>
+          </DialogHeader>
+          <div className="py-4">
+            <input
+              type="text"
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) => changeText(e.target.value)}
+              placeholder="テキストを入力してください"
+              className="w-full p-2 border rounded"
+            />
+          </div>
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+              キャンセル
+            </Button>
+            <Button type="submit">
+              追加
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+} 

--- a/front/src/components/templates/event/venueedit/VenueEditorTemplate.tsx
+++ b/front/src/components/templates/event/venueedit/VenueEditorTemplate.tsx
@@ -8,13 +8,16 @@ import VenueToolSelectionMenu from "./VenueToolSelectionMenu"
 import { useColorPalette } from '@/hooks/event/venueedit/submenu/useColorPalette'
 import { useCanvasDraw } from '@/hooks/event/venueedit/useCanvasDraw'
 import { VenueEditTool } from '@/types/tool'
+import TextDialog from '@/components/organisms/event/venueedit/text/TextDialog'
 
 export default function VenueEditorTemplate() {
   const [selectedTool, setSelectedTool] = useState<VenueEditTool>('ピクセル塗りつぶし')
   const { 
-    selectedColor, 
+    selectedColor,
+    setSelectedColor, 
     colorPalette, 
-    setSelectedColor,
+    selectedColorBackGround,
+    setSelectedColorBackGround,
     addColor,
     removeColor
   } = useColorPalette()
@@ -30,10 +33,15 @@ export default function VenueEditorTemplate() {
     handleMouseDown,
     handleMouseMove,
     handleMouseUp,
-    handleMouseLeave
+    handleMouseLeave,
+    isTextDialogOpen,
+    setIsTextDialogOpen,
+    setCurrentText,
+    handleTextAdd,
   } = useCanvasDraw({
     selectedColor,
-    selectedTool
+    selectedTool,
+    selectedColorBackGround
   })
 
   return (
@@ -62,10 +70,18 @@ export default function VenueEditorTemplate() {
               selectedTool={selectedTool}
               onToolSelect={setSelectedTool}
               selectedColor={selectedColor}
-              onColorSelect={setSelectedColor}
+              setSelectedColor={setSelectedColor}
+              selectedColorBackGround={selectedColorBackGround}
+              setSelectedColorBackGround={setSelectedColorBackGround}
               colorPalette={colorPalette}
               onAddColor={addColor}
               onDeleteColor={removeColor}
+            />
+            <TextDialog
+              isOpen={isTextDialogOpen}
+              onOpenChange={setIsTextDialogOpen}
+              onTextChange={setCurrentText}
+              onAdd={handleTextAdd}
             />
           </div>
           <div className="col-span-1 md:col-span-1 lg:col-span-8 xl:col-span-4">

--- a/front/src/components/templates/event/venueedit/VenueToolSubMenu.tsx
+++ b/front/src/components/templates/event/venueedit/VenueToolSubMenu.tsx
@@ -1,13 +1,16 @@
 import React from 'react'
 import ColorPalette from '@/components/organisms/event/venueedit/palette/ColorPalette'
 import { Color } from '@/types/color'
-import { PIXEL_TOOLS, VenueEditTool, PixelTool } from '@/types/tool'
+import { PIXEL_TOOLS, VenueEditTool, PixelTool, TEXT_TOOLS, TextTool } from '@/types/tool'
+import ColorSingleSelector from '@/components/organisms/event/venueedit/palette/ColorSingleSelector'
 
 interface VenueToolSubMenuProps {
   selectedTool: VenueEditTool
   onToolSelect: (tool: VenueEditTool) => void
   selectedColor: Color
-  onColorSelect: (color: Color) => void
+  setSelectedColor: (color: Color) => void
+  selectedColorBackGround: Color
+  setSelectedColorBackGround: (color: Color) => void
   colorPalette: Color[]
   onAddColor: (color: Color) => void
   onDeleteColor: (color: Color) => void
@@ -17,11 +20,17 @@ function isPixelTool(tool: VenueEditTool): tool is PixelTool {
   return (PIXEL_TOOLS as readonly string[]).includes(tool)
 }
 
+function isTextTool(tool: VenueEditTool): tool is TextTool {
+  return (TEXT_TOOLS as readonly string[]).includes(tool)
+}
+
 export default function VenueToolSubMenu({ 
   selectedTool,
   onToolSelect,
   selectedColor, 
-  onColorSelect,
+  setSelectedColor,
+  selectedColorBackGround,
+  setSelectedColorBackGround,
   colorPalette,
   onAddColor,
   onDeleteColor
@@ -38,11 +47,19 @@ export default function VenueToolSubMenu({
           </div>
           {isPixelTool(selectedTool) && (
             <ColorPalette
-              onColorSelect={onColorSelect}
+              onColorSelect={setSelectedColor}
               selectedColor={selectedColor}
               colors={colorPalette}
               onAddColor={onAddColor}
               onDeleteColor={onDeleteColor}
+            />
+          )}
+          {isTextTool(selectedTool) && (
+            <ColorSingleSelector
+              selectedColor={selectedColor}
+              selectedColorBackGround={selectedColorBackGround}
+              setSelectedColor={setSelectedColor}
+              setSelectedColorBackGround={setSelectedColorBackGround}
             />
           )}
         </div>

--- a/front/src/hooks/event/venueedit/dialog/useTextDialog.ts
+++ b/front/src/hooks/event/venueedit/dialog/useTextDialog.ts
@@ -1,0 +1,56 @@
+import { useState } from 'react'
+import { Position, TextState } from '@/types/event/state'
+import { Color } from '@/types/color'
+
+interface TextDialogProps {
+  textState: TextState[]
+  setTextState: React.Dispatch<React.SetStateAction<TextState[]>>
+  selectedColor: Color
+  selectedColorBackGround?: Color
+}
+
+export const useTextDialog = ({
+  textState,
+  setTextState,
+  selectedColor,
+  selectedColorBackGround,
+}: TextDialogProps) => {
+  const [isTextDialogOpen, setIsTextDialogOpen] = useState(false)
+  const [currentText, setCurrentText] = useState('')
+  const [textPosition, setTextPosition] = useState<Position>({
+    startX: 0,
+    startY: 0,
+    endX: 0,
+    endY: 0
+  })
+
+  const handleTextAdd = () => {
+    console.log("selectedColor", selectedColor)
+    console.log("selectedColorBackGround", selectedColorBackGround)
+    const newTextState: TextState[] = [...textState, {
+      text: currentText,
+      textColor: selectedColor,
+      backgroundColor: selectedColorBackGround ?? null,
+      borderColor: null,
+      orientation: 'horizontal' as const,
+      startX: Math.min(textPosition.startX, textPosition.endX),
+      startY: Math.min(textPosition.startY, textPosition.endY),
+      endX: Math.max(textPosition.startX, textPosition.endX),
+      endY: Math.max(textPosition.startY, textPosition.endY)
+    }]
+    setTextState(newTextState)
+    setIsTextDialogOpen(false)
+  }
+
+  return {
+    isTextDialogOpen,
+    setIsTextDialogOpen,
+    currentText,
+    setCurrentText,
+    textPosition,
+    setTextPosition,
+    handleTextAdd,
+    selectedColor,
+    selectedColorBackGround,
+  }
+}

--- a/front/src/hooks/event/venueedit/submenu/useColorPalette.ts
+++ b/front/src/hooks/event/venueedit/submenu/useColorPalette.ts
@@ -9,9 +9,10 @@ interface UseColorPaletteReturn {
   selectedColor: Color
   colorPalette: Color[]
   setSelectedColor: Dispatch<SetStateAction<Color>>
+  selectedColorBackGround: Color
+  setSelectedColorBackGround: Dispatch<SetStateAction<Color>>
   addColor: (color: Color) => void
   removeColor: (color: Color) => void
-  reorderColors: (fromIndex: number, toIndex: number) => void
   resetColors: () => void
 }
 
@@ -21,6 +22,7 @@ interface UseColorPaletteReturn {
  */
 export const useColorPalette = (): UseColorPaletteReturn => {
   const [selectedColor, setSelectedColor] = useState<Color>(DEFAULT_COLORS[0])
+  const [selectedColorBackGround, setSelectedColorBackGround] = useState<Color>(DEFAULT_COLORS[1])
   const [colorPalette, setColorPalette] = useState<Color[]>(DEFAULT_COLORS)
 
   /**
@@ -47,18 +49,6 @@ export const useColorPalette = (): UseColorPaletteReturn => {
   }
 
   /**
-   * 色の順序を変更する
-   * @param fromIndex 移動元のインデックス
-   * @param toIndex 移動先のインデックス
-   */
-  const reorderColors = (fromIndex: number, toIndex: number) => {
-    const newColors = [...colorPalette]
-    const [removed] = newColors.splice(fromIndex, 1)
-    newColors.splice(toIndex, 0, removed)
-    setColorPalette(newColors)
-  }
-
-  /**
    * カラーパレットをデフォルトにリセットする
    */
   const resetColors = () => {
@@ -70,9 +60,10 @@ export const useColorPalette = (): UseColorPaletteReturn => {
     selectedColor,
     colorPalette,
     setSelectedColor,
+    selectedColorBackGround,
+    setSelectedColorBackGround,
     addColor,
     removeColor,
-    reorderColors,
     resetColors
   }
 } 

--- a/front/src/hooks/event/venueedit/tool/useCellEditableTool.ts
+++ b/front/src/hooks/event/venueedit/tool/useCellEditableTool.ts
@@ -2,12 +2,14 @@ import { useCallback, useRef, useState } from 'react'
 import { Color } from '@/types/color'
 import { getCellCoordinates, syncPixelStateToCanvas } from '@/lib/event/venueedit/canvasControl'
 import { CANVAS_BASE } from '@/lib/event/venueedit/constants'
+import { TextState } from '@/types/event/state'
 
 interface Props {
   canvasRef: React.RefObject<HTMLCanvasElement | null>
   numPixel: number
   pixelColorState: (Color | null)[][]
   circleColorState: (Color | null)[][]
+  textState: TextState[]
   updatePixelState?: (x: number, y: number) => (Color | null)[][]
   updateCircleState?: (x: number, y: number) => (Color | null)[][]
 }
@@ -25,6 +27,7 @@ export const useCellEditableTool = ({
   numPixel, 
   pixelColorState,
   circleColorState,
+  textState,
   updatePixelState,
   updateCircleState
 }: Props) => {
@@ -33,8 +36,8 @@ export const useCellEditableTool = ({
   const CELL_SIZE = CANVAS_BASE / numPixel
 
   const syncToCanvas = useCallback((x: number, y: number, ctx: CanvasRenderingContext2D, pixelState: (Color | null)[][], circleState: (Color | null)[][]) => {
-    syncPixelStateToCanvas(ctx, x, y, CELL_SIZE, pixelState, circleState)
-  }, [CELL_SIZE])
+    syncPixelStateToCanvas(ctx, x, y, CELL_SIZE, pixelState, circleState, textState)
+  }, [CELL_SIZE, textState])
 
   /**
    * マウスダウン（マウスボタンを押したとき）
@@ -52,9 +55,9 @@ export const useCellEditableTool = ({
     lastCellRef.current = { x: coords.cellX, y: coords.cellY }
     const newPixelColorState = updatePixelState ? updatePixelState(coords.cellX, coords.cellY) : pixelColorState
     const newCircleColorState = updateCircleState ? updateCircleState(coords.cellX, coords.cellY) : circleColorState
-    syncToCanvas(coords.cellX, coords.cellY, ctx, newPixelColorState, newCircleColorState)
+    syncToCanvas(coords.cellX, coords.cellY, ctx, newPixelColorState, newCircleColorState,)
 
-  }, [pixelColorState, updatePixelState, circleColorState, updateCircleState])
+  }, [pixelColorState, updatePixelState, circleColorState, updateCircleState, textState])
 
   /**
    * マウスを動かしている時
@@ -78,6 +81,7 @@ export const useCellEditableTool = ({
     const newPixelColorState = updatePixelState ? updatePixelState(coords.cellX, coords.cellY) : pixelColorState
     const newCircleColorState = updateCircleState ? updateCircleState(coords.cellX, coords.cellY) : circleColorState
     syncToCanvas(coords.cellX, coords.cellY, ctx, newPixelColorState, newCircleColorState)
+    
   }, [isDrawing, pixelColorState, updatePixelState, circleColorState, updateCircleState])
 
   /**

--- a/front/src/hooks/event/venueedit/tool/useCircleDraw.ts
+++ b/front/src/hooks/event/venueedit/tool/useCircleDraw.ts
@@ -1,6 +1,7 @@
 import { useCallback } from 'react'
 import { Color } from '@/types/color'
 import { useCellEditableTool } from '@/hooks/event/venueedit/tool/useCellEditableTool'
+import { TextState } from '@/types/event/state'
 
 interface Props {
   canvasRef: React.RefObject<HTMLCanvasElement | null>
@@ -9,10 +10,11 @@ interface Props {
   setPixelColorState: React.Dispatch<React.SetStateAction<(Color | null)[][]>>
   pixelColorState: (Color | null)[][]
   setCircleColorState: React.Dispatch<React.SetStateAction<(Color | null)[][]>>
-  circleColorState: (Color | null)[][]
+  circleColorState: (Color | null)[][]    
+  textState: TextState[]
 }
 
-export const useCircleDraw = ({ canvasRef, numPixel, selectedColor, setCircleColorState, pixelColorState, circleColorState }: Props) => {
+export const useCircleDraw = ({ canvasRef, numPixel, selectedColor, setCircleColorState, pixelColorState, circleColorState, textState }: Props) => {
   const updateCircleState = useCallback((x: number, y: number) => {
     const newState = [...circleColorState]
     newState[y] = [...newState[y]]
@@ -26,6 +28,7 @@ export const useCircleDraw = ({ canvasRef, numPixel, selectedColor, setCircleCol
     numPixel,
     pixelColorState,
     circleColorState,
-    updateCircleState
+    updateCircleState,
+    textState
   })
 } 

--- a/front/src/hooks/event/venueedit/tool/useCircleErase.ts
+++ b/front/src/hooks/event/venueedit/tool/useCircleErase.ts
@@ -1,6 +1,7 @@
 import { useCallback } from 'react'
 import { Color } from '@/types/color'
 import { useCellEditableTool } from '@/hooks/event/venueedit/tool/useCellEditableTool'
+import { TextState } from '@/types/event/state'
 
 interface Props {
   canvasRef: React.RefObject<HTMLCanvasElement | null>
@@ -9,9 +10,10 @@ interface Props {
   pixelColorState: (Color | null)[][]
   setCircleColorState: React.Dispatch<React.SetStateAction<(Color | null)[][]>>
   circleColorState: (Color | null)[][]
+  textState: TextState[]
 }
 
-export const useCircleErase = ({ canvasRef, numPixel, setCircleColorState, pixelColorState, circleColorState }: Props) => {
+export const useCircleErase = ({ canvasRef, numPixel, selectedColor, setCircleColorState, pixelColorState, circleColorState, textState }: Props) => {
   const updateCircleState = useCallback((x: number, y: number) => {
     const newState = [...circleColorState]
     newState[y] = [...newState[y]]
@@ -25,6 +27,7 @@ export const useCircleErase = ({ canvasRef, numPixel, setCircleColorState, pixel
     numPixel,
     pixelColorState,
     circleColorState,
-    updateCircleState
+    updateCircleState,
+    textState
   })
 } 

--- a/front/src/hooks/event/venueedit/tool/useDragging.ts
+++ b/front/src/hooks/event/venueedit/tool/useDragging.ts
@@ -1,0 +1,103 @@
+import { getCellCoordinates, syncDraggingStateToCanvas } from "@/lib/event/venueedit/canvasControl"
+import { CANVAS_BASE } from "@/lib/event/venueedit/constants"
+import { useCallback, useRef, useState } from "react"
+
+interface Props {
+  canvasRef: React.RefObject<HTMLCanvasElement | null>
+  numPixel: number
+  color: string
+  handleMouseRelieve: (startX: number, startY: number, endX: number, endY: number) => void
+}
+
+export const useDragging = ({ canvasRef, numPixel, color, handleMouseRelieve }: Props) => {
+
+  const [isDrawing, setIsDrawing] = useState(false)
+  const [startX, setStartX] = useState<number | null>(null)
+  const [startY, setStartY] = useState<number | null>(null)
+  const [endX, setEndX] = useState<number | null>(null)
+  const [endY, setEndY] = useState<number | null>(null)
+
+  const lastCellRef = useRef<{ x: number; y: number } | null>(null)
+  const CELL_SIZE = CANVAS_BASE / numPixel
+
+  const syncToCanvas = useCallback((ctx: CanvasRenderingContext2D, startX: number | null, startY: number | null, endX: number | null, endY: number | null) => {
+    if (startX === null || startY === null || endX === null || endY === null) return
+    syncDraggingStateToCanvas(ctx, startX, startY, endX, endY, CELL_SIZE, color)
+  }, [CELL_SIZE, color])
+
+  const handleMouseDown = useCallback((e: React.MouseEvent<HTMLCanvasElement>) => {
+    setIsDrawing(true)
+
+    const coords = getCellCoordinates(e.clientX, e.clientY, canvasRef, CELL_SIZE, numPixel)
+    if (!coords) return
+
+    const canvas = canvasRef.current
+    if (!canvas) return
+    const ctx = canvas.getContext('2d')
+    if (!ctx) return
+    lastCellRef.current = { x: coords.cellX, y: coords.cellY }
+    setStartX(coords.cellX)
+    setStartY(coords.cellY)
+    setEndX(coords.cellX)
+    setEndY(coords.cellY)
+    syncToCanvas(ctx, coords.cellX, coords.cellY, coords.cellX, coords.cellY)
+  }, [canvasRef, numPixel])
+
+  const handleMouseMove = useCallback((e: React.MouseEvent<HTMLCanvasElement>) => {
+    if (!isDrawing) return
+    const coords = getCellCoordinates(e.clientX, e.clientY, canvasRef, CELL_SIZE, numPixel)
+    if (!coords) return
+    // 同じセルの場合は描画しない
+    if (lastCellRef.current?.x === coords.cellX && lastCellRef.current?.y === coords.cellY) {
+      return
+    }
+    const canvas = canvasRef.current
+    if (!canvas) return
+    const ctx = canvas.getContext('2d')
+    if (!ctx) return
+
+    lastCellRef.current = { x: coords.cellX, y: coords.cellY }
+    setEndX(coords.cellX)
+    setEndY(coords.cellY)
+    syncToCanvas(ctx, startX, startY, coords.cellX, coords.cellY)
+  }, [canvasRef, numPixel, isDrawing, startX, startY, endX, endY])
+
+  const handleMouseUp = useCallback((e?: React.MouseEvent<HTMLCanvasElement>) => {
+    setIsDrawing(false)
+    if (endX === null || endY === null) return
+
+    const canvas = canvasRef.current
+    if (!canvas) return
+    const ctx = canvas.getContext('2d')
+    if (!ctx) return
+    syncToCanvas(ctx, startX, startY, endX, endY)
+
+    if (startX !== null && startY !== null) {
+      handleMouseRelieve(startX, startY, endX, endY)
+    }
+  }, [canvasRef, startX, startY, endX, endY, handleMouseRelieve])
+
+  const handleMouseLeave = useCallback((e?: React.MouseEvent<HTMLCanvasElement>) => {
+    if (!isDrawing) return
+    setIsDrawing(false)
+    if (endX === null || endY === null) return
+
+    const canvas = canvasRef.current
+    if (!canvas) return
+    const ctx = canvas.getContext('2d')
+    if (!ctx) return
+    syncToCanvas(ctx, startX, startY, endX, endY)
+
+    if (startX !== null && startY !== null) {
+      handleMouseRelieve(startX, startY, endX, endY)
+    }
+  }, [canvasRef, startX, startY, endX, endY, handleMouseRelieve, isDrawing])
+
+  return {
+    handleMouseDown,
+    handleMouseMove,
+    handleMouseUp,
+    handleMouseLeave
+  }
+
+}

--- a/front/src/hooks/event/venueedit/tool/usePixelDraw.ts
+++ b/front/src/hooks/event/venueedit/tool/usePixelDraw.ts
@@ -1,6 +1,7 @@
 import { useCallback } from 'react'
 import { Color } from '@/types/color'
 import { useCellEditableTool } from '@/hooks/event/venueedit/tool/useCellEditableTool'
+import { TextState } from '@/types/event/state'
 
 interface Props {
   canvasRef: React.RefObject<HTMLCanvasElement | null>
@@ -10,9 +11,10 @@ interface Props {
   pixelColorState: (Color | null)[][]
   setCircleColorState: React.Dispatch<React.SetStateAction<(Color | null)[][]>>
   circleColorState: (Color | null)[][]
+  textState: TextState[]
 }
 
-export const usePixelDraw = ({ canvasRef, numPixel, selectedColor, setPixelColorState, pixelColorState, circleColorState }: Props) => {
+export const usePixelDraw = ({ canvasRef, numPixel, selectedColor, setPixelColorState, pixelColorState, circleColorState, textState }: Props) => {
   const updatePixelState = useCallback((x: number, y: number) => {
     const newState = [...pixelColorState]
     newState[y] = [...newState[y]]
@@ -26,6 +28,7 @@ export const usePixelDraw = ({ canvasRef, numPixel, selectedColor, setPixelColor
     numPixel,
     pixelColorState,
     circleColorState,
-    updatePixelState
+    updatePixelState,
+    textState
   })
 } 

--- a/front/src/hooks/event/venueedit/tool/usePixelErase.ts
+++ b/front/src/hooks/event/venueedit/tool/usePixelErase.ts
@@ -1,6 +1,7 @@
 import { useCallback } from 'react'
 import { Color } from '@/types/color'
 import { useCellEditableTool } from '@/hooks/event/venueedit/tool/useCellEditableTool'
+import { TextState } from '@/types/event/state'
 
 interface Props {
   canvasRef: React.RefObject<HTMLCanvasElement | null>
@@ -9,9 +10,10 @@ interface Props {
   pixelColorState: (Color | null)[][]
   setCircleColorState: React.Dispatch<React.SetStateAction<(Color | null)[][]>>
   circleColorState: (Color | null)[][]
+  textState: TextState[]
 }
 
-export const usePixelErase = ({ canvasRef, numPixel, setPixelColorState, pixelColorState, setCircleColorState, circleColorState }: Props) => {
+export const usePixelErase = ({ canvasRef, numPixel, setPixelColorState, pixelColorState, setCircleColorState, circleColorState, textState }: Props) => {
   const updatePixelState = useCallback((x: number, y: number) => {
     const newState = [...pixelColorState]
     newState[y] = [...newState[y]]
@@ -25,6 +27,7 @@ export const usePixelErase = ({ canvasRef, numPixel, setPixelColorState, pixelCo
     numPixel,
     pixelColorState,
     circleColorState,
-    updatePixelState
+    updatePixelState,
+    textState
   })
 } 

--- a/front/src/hooks/event/venueedit/tool/useTextAdd.ts
+++ b/front/src/hooks/event/venueedit/tool/useTextAdd.ts
@@ -1,0 +1,18 @@
+import { useDragging } from '@/hooks/event/venueedit/tool/useDragging'
+
+interface Props {
+  canvasRef: React.RefObject<HTMLCanvasElement | null>
+  numPixel: number
+  color: string
+  handleMouseRelieveText: (startX: number, startY: number, endX: number, endY: number) => void
+}
+
+export const useTextAdd = ({ canvasRef, numPixel, color, handleMouseRelieveText }: Props) => {
+
+  return useDragging({
+    canvasRef,
+    numPixel,
+    color,
+    handleMouseRelieve: handleMouseRelieveText
+  })
+} 

--- a/front/src/hooks/event/venueedit/tool/useToolSelect.ts
+++ b/front/src/hooks/event/venueedit/tool/useToolSelect.ts
@@ -5,34 +5,42 @@ import { usePixelErase } from '@/hooks/event/venueedit/tool/usePixelErase'
 import { useCircleDraw } from '@/hooks/event/venueedit/tool/useCircleDraw'
 import { Color } from '@/types/color'
 import { useCircleErase } from '@/hooks/event/venueedit/tool/useCircleErase'
+import { useTextAdd } from '@/hooks/event/venueedit/tool/useTextAdd'
+import { TextState } from '@/types/event/state'
 
 interface Props {
   selectedTool: VenueEditTool
   selectedColor: Color
+  selectedColorBackGround?: Color
   canvasRef: React.RefObject<HTMLCanvasElement | null>
   numPixel: number
   pixelColorState: (Color | null)[][]
   setPixelColorState: React.Dispatch<React.SetStateAction<(Color | null)[][]>>
   setCircleColorState: React.Dispatch<React.SetStateAction<(Color | null)[][]>>
   circleColorState: (Color | null)[][]
+  handleMouseRelieveText: (startX: number, startY: number, endX: number, endY: number) => void
+  textState: TextState[]
 }
 
 type ToolHandlers = {
   handleMouseDown: (e: React.MouseEvent<HTMLCanvasElement>) => void
   handleMouseMove: (e: React.MouseEvent<HTMLCanvasElement>) => void
-  handleMouseUp: () => void
+  handleMouseUp: (e?: React.MouseEvent<HTMLCanvasElement>) => void
   handleMouseLeave: () => void
 }
 
 export const useToolSelect = ({ 
   selectedTool,
   selectedColor,
+  selectedColorBackGround,
   canvasRef,
   numPixel,
   pixelColorState,
   setPixelColorState,
   setCircleColorState,
-  circleColorState
+  circleColorState,
+  handleMouseRelieveText,
+  textState
 }: Props) => {
   const canDraw = useCallback(() => {
     return DRAWABLE_TOOLS.includes(selectedTool as DrawableTool)
@@ -45,7 +53,8 @@ export const useToolSelect = ({
     setPixelColorState,
     pixelColorState,
     setCircleColorState,
-    circleColorState
+    circleColorState,
+    textState
   })
 
   const pixelErase = usePixelErase({
@@ -53,8 +62,9 @@ export const useToolSelect = ({
     numPixel,
     setPixelColorState,
     pixelColorState,
-    setCircleColorState,
-    circleColorState
+    setCircleColorState,    
+    circleColorState,
+    textState
   })
 
   const circleDraw = useCircleDraw({
@@ -64,7 +74,8 @@ export const useToolSelect = ({
     setPixelColorState,
     pixelColorState,
     setCircleColorState,
-    circleColorState
+    circleColorState,
+    textState
   })
 
   const circleErase = useCircleErase({
@@ -74,7 +85,15 @@ export const useToolSelect = ({
     setPixelColorState,
     pixelColorState,
     setCircleColorState,
-    circleColorState
+    circleColorState,
+    textState
+  })
+
+  const textAdd = useTextAdd({
+    canvasRef,
+    numPixel,
+    color: '#FFFF00',
+    handleMouseRelieveText
   })
 
   const toolHandlers: Partial<Record<VenueEditTool, ToolHandlers>> = {
@@ -82,6 +101,7 @@ export const useToolSelect = ({
     'ピクセル消去': pixelErase,
     '丸オブジェクト配置': circleDraw,
     '丸オブジェクト消去': circleErase,
+    'テキストボックス追加': textAdd,
   }
 
   const createHandler = (eventName: keyof ToolHandlers) => {
@@ -108,6 +128,6 @@ export const useToolSelect = ({
     handleMouseDown,
     handleMouseMove,
     handleMouseUp,
-    handleMouseLeave
+    handleMouseLeave,
   }
 } 

--- a/front/src/hooks/event/venueedit/useCanvasDraw.ts
+++ b/front/src/hooks/event/venueedit/useCanvasDraw.ts
@@ -1,10 +1,12 @@
-import { useRef, useEffect, useState } from 'react'
-import { initializeCanvas } from '@/lib/event/venueedit/canvasControl'
+import { useRef, useEffect, useState, useCallback } from 'react'
+import { initializeCanvas, syncAllStateToCanvas } from '@/lib/event/venueedit/canvasControl'
 import { VenueEditTool } from '@/types/tool'
-import { Color, color } from '@/types/color'
+import { Color } from '@/types/color'
 import { useZoom } from '@/hooks/event/venueedit/useZoom'
-import { DEFAULT_NUM_PIXEL } from '@/lib/event/venueedit/constants'
+import { DEFAULT_NUM_PIXEL, CANVAS_BASE } from '@/lib/event/venueedit/constants'
 import { useToolSelect } from '@/hooks/event/venueedit/tool/useToolSelect'
+import { useTextDialog } from '@/hooks/event/venueedit/dialog/useTextDialog'
+import { TextState } from '@/types/event/state'
 
 /**
  * キャンバスの描画を管理するフックのProps
@@ -12,8 +14,9 @@ import { useToolSelect } from '@/hooks/event/venueedit/tool/useToolSelect'
  * @param selectedTool 選択されたツール
  */
 interface Props {
-  selectedColor?: Color
-  selectedTool?: VenueEditTool
+  selectedColor: Color
+  selectedTool: VenueEditTool
+  selectedColorBackGround?: Color
 }
 
 /**
@@ -23,43 +26,90 @@ interface Props {
  * @returns キャンバスの参照、キャンバスのサイズ、セルの座標を取得する関数、描画関数
  */
 export const useCanvasDraw = ({ 
-  selectedColor = color('#000000'),
-  selectedTool = 'ピクセル塗りつぶし'
+  selectedColor,
+  selectedTool,
+  selectedColorBackGround
 }: Props) => {
   const canvasRef = useRef<HTMLCanvasElement>(null)
   const [numPixel, setNumPixel] = useState(DEFAULT_NUM_PIXEL)
   const {zoom, handleZoomIn, handleZoomOut} = useZoom()
+
   const [pixelColorState, setPixelColorState] = useState<(Color | null)[][]>(
     Array(numPixel).fill(null).map(() => Array(numPixel).fill(null))
   )
   const [circleColorState, setCircleColorState] = useState<(Color | null)[][]>(
     Array(numPixel).fill(null).map(() => Array(numPixel).fill(null))
   )
+  const [textState, setTextState] = useState<TextState[]>([])
+
+  const syncAllState = useCallback((ctx: CanvasRenderingContext2D) => {
+    syncAllStateToCanvas(ctx, numPixel, CANVAS_BASE / numPixel, pixelColorState, circleColorState, textState)
+  }, [numPixel, pixelColorState, circleColorState, textState])
+  
+  const {
+    isTextDialogOpen,
+    setIsTextDialogOpen,
+    currentText,
+    setCurrentText,
+    textPosition,
+    setTextPosition,
+    handleTextAdd,
+  } = useTextDialog({
+    selectedColor,
+    selectedColorBackGround,
+    textState,
+    setTextState,
+  })
+
+  // isTextDialogOpenの変更も検知して、StateとCanvasの同期を行う
+  useEffect(() => {
+    const ctx = canvasRef.current?.getContext('2d')
+    if (ctx) {
+      syncAllState(ctx)
+    }
+  }, [syncAllState, isTextDialogOpen])
+
+  // numPixelの変更が実施されたら、Stateをリセットする
   useEffect(() => {
     const canvas = canvasRef.current
     if (!canvas) return
 
-    const ctx = initializeCanvas(canvas, numPixel, pixelColorState)
+    const ctx = initializeCanvas(canvas, numPixel)
     if (!ctx) return
 
     setPixelColorState(Array(numPixel).fill(null).map(() => Array(numPixel).fill(null)))
     setCircleColorState(Array(numPixel).fill(null).map(() => Array(numPixel).fill(null)))
+    setTextState([])
+    syncAllState(ctx)
   }, [numPixel])
 
-  const { canDraw, handleMouseDown, handleMouseMove, handleMouseUp, handleMouseLeave } = useToolSelect({
+  const handleMouseRelieveText = useCallback((startX: number, startY: number, endX: number, endY: number) => {
+    setIsTextDialogOpen(true)
+    setTextPosition({
+      startX,
+      startY,
+      endX,
+      endY
+    })
+  }, [selectedColor, selectedColorBackGround])
+
+  const { canDraw: toolCanDraw, handleMouseDown, handleMouseMove, handleMouseUp, handleMouseLeave } = useToolSelect({
     selectedTool,
     selectedColor,
+    selectedColorBackGround,
     canvasRef,
     numPixel,
     setPixelColorState,
     pixelColorState,
     setCircleColorState,
-    circleColorState
+    circleColorState,
+    handleMouseRelieveText,
+    textState,
   })
 
   return { 
     canvasRef, 
-    canDraw,
+    canDraw: toolCanDraw,
     zoom,
     numPixel,
     handleZoomIn,
@@ -68,6 +118,13 @@ export const useCanvasDraw = ({
     handleMouseMove,
     handleMouseUp,
     handleMouseLeave,
-    setNumPixel
+    setNumPixel,
+    isTextDialogOpen,
+    setIsTextDialogOpen,
+    currentText,
+    setCurrentText,
+    textPosition,
+    setTextPosition,
+    handleTextAdd,
   }
 } 

--- a/front/src/lib/event/venueedit/canvasControl.ts
+++ b/front/src/lib/event/venueedit/canvasControl.ts
@@ -1,3 +1,4 @@
+import { TextState } from '@/types/event/state'
 import { CANVAS_BASE } from './constants'
 import { Color } from '@/types/color'
 
@@ -137,6 +138,24 @@ export const drawColoredCell = (ctx: CanvasRenderingContext2D, cellX : number, c
 }
 
 /**
+ * 色付きセルを描画する
+ * @param ctx キャンバスのコンテキスト
+ * @param cellX セルのx座標インデックス
+ * @param cellY セルのy座標インデックス
+ * @param numCellX セルのx方向の数
+ * @param numCellY セルのy方向の数
+ * @param cellSize セルサイズ
+ * @param color 色
+ */
+export const drawColoredSquare = (ctx: CanvasRenderingContext2D, cellX : number, cellY: number, cellSize: number, numCellX: number, numCellY: number, color: string) => {
+  // パターンまたは色を描画
+  if (color !== null) {
+    ctx.fillStyle = color.toString()
+    ctx.fillRect(cellX * cellSize, cellY * cellSize, numCellX * cellSize, numCellY * cellSize)
+  }
+}
+
+/**
  * マウス座標からセルの座標を取得する
  * @param x マウスのx座標
  * @param y マウスのy座標
@@ -178,7 +197,6 @@ export const getCellCoordinates = (
 export const initializeCanvas = (
   canvas: HTMLCanvasElement,
   numPixel: number,
-  pixelColorState: (Color | null)[][]
 ) => {
   const ctx = canvas.getContext('2d')
   if (!ctx) return null
@@ -213,10 +231,15 @@ export const syncPixelStateToCanvas = (
   cellY: number,
   cellSize: number,
   pixelColorState: (Color | null)[][],
-  circleColorState: (Color | null)[][]
+  circleColorState: (Color | null)[][],
+  textState: TextState[]
 ) => {
   const pixelColor = pixelColorState[cellY]?.[cellX]
   const circleColor = circleColorState[cellY]?.[cellX]
+
+  if (textState.some(text => text.startX <= cellX && text.endX >= cellX && text.startY <= cellY && text.endY >= cellY)) {
+    return;
+  }
 
   // セルを色で塗る
   if (pixelColor != null) {
@@ -229,6 +252,60 @@ export const syncPixelStateToCanvas = (
   // 円を描画
   if (circleColor != null) {
     drawCircle(ctx, cellX, cellY, cellSize, circleColor)
+  }
+}
+
+/**
+ * ドラッグ中の状態をキャンバスに反映する
+ * @param ctx キャンバスのコンテキスト
+ * @param startX 開始X座標
+ * @param startY 開始Y座標
+ * @param endX 終了X座標
+ * @param endY 終了Y座標
+ * @param cellSize セルサイズ
+ * @param color 色
+ */
+export const syncDraggingStateToCanvas = (
+  ctx: CanvasRenderingContext2D,
+  startX: number,
+  startY: number,
+  endX: number,
+  endY: number,
+  cellSize: number,
+  color: string
+) => {
+
+  const fillStartX = Math.min(startX, endX)
+  const fillStartY = Math.min(startY, endY)
+  const fillEndX = Math.max(startX, endX)
+  const fillEndY = Math.max(startY, endY)
+
+  const cellSizeX = (fillEndX - fillStartX + 1) * cellSize
+  const cellSizeY = (fillEndY - fillStartY + 1) * cellSize
+
+  ctx.fillStyle = color.toString()
+  ctx.fillRect(fillStartX * cellSize, fillStartY * cellSize, cellSizeX, cellSizeY)
+
+}
+
+export const syncAllStateToCanvas = (
+  ctx: CanvasRenderingContext2D,
+  numPixel: number,
+  cellSize: number,
+  pixelColorState: (Color | null)[][],
+  circleColorState: (Color | null)[][],
+  textState: TextState[]
+) => {
+  for (let i = 0; i < numPixel; i++) {
+    for (let j = 0; j < numPixel; j++) {
+      syncPixelStateToCanvas(ctx, i, j, cellSize, pixelColorState, circleColorState, textState)
+    }
+  }
+  for (const text of textState) {
+    if (text.backgroundColor != null) {
+    drawColoredSquare(ctx, text.startX, text.startY, cellSize, text.endX - text.startX + 1, text.endY - text.startY + 1, text.backgroundColor.toString())
+    }
+    drawText(ctx, cellSize, text)
   }
 }
 
@@ -249,4 +326,40 @@ export const drawCircle = (ctx: CanvasRenderingContext2D, cellX: number, cellY: 
   ctx.beginPath()
   ctx.arc(centerX, centerY, radius, 0, Math.PI * 2)
   ctx.fill()
+}
+
+/**
+ * テキストを描画する
+ * @param ctx キャンバスのコンテキスト
+ * @param text 描画するテキスト
+ * @param startX 開始X座標
+ * @param startY 開始Y座標
+ * @param endX 終了X座標
+ * @param endY 終了Y座標
+ * @param cellSize セルサイズ
+ */
+export const drawText = (
+  ctx: CanvasRenderingContext2D,
+  cellSize: number,
+  text: TextState
+) => {
+  const startX = text.startX
+  const startY = text.startY
+  const endX = text.endX
+  const endY = text.endY
+  const backgroundColor = text.backgroundColor
+  const textColor = text.textColor
+  const textLength = text.text.length
+
+  const fontSize = Math.min(((Math.abs(endX - startX) + 1) * cellSize)/textLength, (Math.abs(endY - startY)+1) * cellSize) // yの方は長さでは割らない
+  ctx.fillStyle = textColor.toString()
+  ctx.font = `${fontSize}px sans-serif`
+  
+  // 文字の配置を計算
+  const x = ((startX + endX) / 2 + 0.5) * cellSize
+  const y = ((startY + endY) / 2 + 0.5) * cellSize
+
+  ctx.textAlign = 'center'
+  ctx.textBaseline = 'middle'
+  ctx.fillText(text.text, x, y)
 } 

--- a/front/src/types/event/state.ts
+++ b/front/src/types/event/state.ts
@@ -1,0 +1,20 @@
+import { Color } from "react-color"
+
+export type TextState = {  
+  text: string
+  startX: number
+  startY: number
+  endX: number
+  endY: number
+  textColor: Color
+  backgroundColor: Color | null
+  borderColor: Color | null
+  orientation: 'horizontal' | 'vertical'
+}
+
+export type Position = {
+  startX: number
+  startY: number
+  endX: number
+  endY: number
+}


### PR DESCRIPTION
テキストボックスを追加できるようにしました。
以下、検証用URLです。
http://localhost:3000/event/venueedit/sample

イメージはこんな感じです。
<img width="1466" alt="image" src="https://github.com/user-attachments/assets/06474682-1aaa-4111-b635-521a6fe084ac" />
