### PR TITLE
Feature/#66 ユーザーグループ登録機能

### DIFF
--- a/front/src/actions/user_group/registerUserGroup.ts
+++ b/front/src/actions/user_group/registerUserGroup.ts
@@ -1,7 +1,7 @@
 'use server';
 
 import { auth } from '@/lib/auth/auth';
-import { insertUserGroup } from '@/lib/db/user_group';
+import { insertUserGroup, selectUserGroupByName } from '@/lib/db/user_group';
 
 export async function registerUserGroup(
   _prevState: { success: boolean; error: string },
@@ -12,8 +12,17 @@ export async function registerUserGroup(
     return { success: false, error: 'ログインしていません' };
   }
 
-  const name = formData.get('name')?.toString() || '';
-  const description = formData.get('description')?.toString() || '';
+  const name = formData.get('name')?.toString().trim();
+  const description = formData.get('description')?.toString().trim() ?? '';
+
+  if (!name) {
+    return { success: false, error: 'グループ名は必須です' };
+  }
+
+  const existing = await selectUserGroupByName(name);
+  if (existing) {
+    return { success: false, error: 'このグループ名はすでに使われています' };
+  }
 
   try {
     await insertUserGroup({ name, description });

--- a/front/src/actions/user_group/registerUserGroup.ts
+++ b/front/src/actions/user_group/registerUserGroup.ts
@@ -1,0 +1,27 @@
+'use server';
+
+import { auth } from '@/lib/auth/auth';
+import { insertUserGroup } from '@/lib/db/user_group';
+
+export async function registerUserGroup(
+  _prevState: { success: boolean; error: string },
+  formData: FormData
+): Promise<{ success: boolean; error: string }> {
+  const session = await auth();
+  if (!session?.user?.email) {
+    return { success: false, error: 'ログインしていません' };
+  }
+
+  const name = formData.get('name')?.toString() || '';
+  const description = formData.get('description')?.toString() || '';
+
+  try {
+    await insertUserGroup({ name, description });
+    return { success: true, error: '' };
+  } catch (e: any) {
+    return {
+      success: false,
+      error: e?.message || '登録に失敗しました',
+    };
+  }
+}

--- a/front/src/app/user_group/register/page.tsx
+++ b/front/src/app/user_group/register/page.tsx
@@ -1,0 +1,5 @@
+import UserGroupTemplate from "@/components/templates/user_group/UserGroupRegisterTemplate"
+
+export default function UserGroupPage() {
+  return <UserGroupTemplate />
+}

--- a/front/src/components/templates/user_group/UserGroupRegisterTemplate.tsx
+++ b/front/src/components/templates/user_group/UserGroupRegisterTemplate.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import { registerUserGroup } from '@/actions/user_group/registerUserGroup';
+import { useActionState } from 'react'; // ← 修正ポイント
+import type { FormEvent } from 'react';
+
+export default function UserGroupRegisterTemplate() {
+  const router = useRouter();
+  const initialState = { success: false, error: '' };
+  const [state, formAction] = useActionState(registerUserGroup, initialState);
+
+  useEffect(() => {
+    if (state.success) {
+      router.push('/');
+    }
+  }, [state.success, router]);
+
+  return (
+    <div className="max-w-md mx-auto mt-10 p-4 border rounded shadow">
+      <h1 className="text-xl font-bold mb-4">ユーザーグループ登録</h1>
+      <form action={formAction} className="space-y-4">
+        <div>
+          <label className="block mb-1 font-medium">グループ名</label>
+          <input
+            type="text"
+            name="name"
+            required
+            className="w-full border px-3 py-2 rounded"
+          />
+        </div>
+
+        <div>
+          <label className="block mb-1 font-medium">グループの概要</label>
+          <textarea
+            name="description"
+            rows={6}
+            className="w-full border px-3 py-2 rounded"
+          />
+        </div>
+
+        {state.error && <p className="text-red-600">{state.error}</p>}
+        {state.success && <p className="text-green-600">登録に成功しました！</p>}
+
+        <div className="text-center">
+          <button type="submit" className="bg-blue-600 text-white px-6 py-2 rounded">
+            登録
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/front/src/components/templates/user_group/UserGroupRegisterTemplate.tsx
+++ b/front/src/components/templates/user_group/UserGroupRegisterTemplate.tsx
@@ -1,13 +1,14 @@
 'use client';
 
-import { useEffect } from 'react';
+import { useActionState } from 'react';
 import { useRouter } from 'next/navigation';
 import { registerUserGroup } from '@/actions/user_group/registerUserGroup';
-import { useActionState } from 'react'; // ← 修正ポイント
-import type { FormEvent } from 'react';
+import { useEffect, useState } from 'react';
 
 export default function UserGroupRegisterTemplate() {
   const router = useRouter();
+  const [name, setName] = useState('');
+  const [description, setDescription] = useState('');
   const initialState = { success: false, error: '' };
   const [state, formAction] = useActionState(registerUserGroup, initialState);
 
@@ -20,12 +21,23 @@ export default function UserGroupRegisterTemplate() {
   return (
     <div className="max-w-md mx-auto mt-10 p-4 border rounded shadow">
       <h1 className="text-xl font-bold mb-4">ユーザーグループ登録</h1>
-      <form action={formAction} className="space-y-4">
+
+      {/* hidden inputsでuseActionStateに値を渡す */}
+      <form
+        action={(formData) => {
+          formData.set('name', name);
+          formData.set('description', description);
+          return formAction(formData);
+        }}
+        className="space-y-4"
+      >
         <div>
           <label className="block mb-1 font-medium">グループ名</label>
           <input
             type="text"
             name="name"
+            value={name}
+            onChange={e => setName(e.target.value)}
             required
             className="w-full border px-3 py-2 rounded"
           />
@@ -36,6 +48,8 @@ export default function UserGroupRegisterTemplate() {
           <textarea
             name="description"
             rows={6}
+            value={description}
+            onChange={e => setDescription(e.target.value)}
             className="w-full border px-3 py-2 rounded"
           />
         </div>

--- a/front/src/lib/db/schema/index.ts
+++ b/front/src/lib/db/schema/index.ts
@@ -1,1 +1,2 @@
 export * from "./user";
+export * from "./user_group";

--- a/front/src/lib/db/schema/user_group.ts
+++ b/front/src/lib/db/schema/user_group.ts
@@ -7,7 +7,7 @@ import {
 
   export const userGroups = pgTable("user_groups", {
     id: bigint("id", { mode: "number" }).primaryKey().generatedAlwaysAsIdentity(),
-    name: text("name").notNull(),
+    name: text("name").notNull().unique(),
     description: text("description"),
     createdAt: timestamp("created_at", { mode: "date" }).notNull().defaultNow(),
     updatedAt: timestamp("updated_at", { mode: "date" }).notNull().defaultNow(),

--- a/front/src/lib/db/schema/user_group.ts
+++ b/front/src/lib/db/schema/user_group.ts
@@ -1,0 +1,14 @@
+import {
+    pgTable,
+    bigint,
+    text,
+    timestamp,
+  } from "drizzle-orm/pg-core";
+
+  export const userGroups = pgTable("user_groups", {
+    id: bigint("id", { mode: "number" }).primaryKey().generatedAlwaysAsIdentity(),
+    name: text("name").notNull(),
+    description: text("description"),
+    createdAt: timestamp("created_at", { mode: "date" }).notNull().defaultNow(),
+    updatedAt: timestamp("updated_at", { mode: "date" }).notNull().defaultNow(),
+  });

--- a/front/src/lib/db/user_group.ts
+++ b/front/src/lib/db/user_group.ts
@@ -1,0 +1,15 @@
+import { db } from '@/lib/db';
+import { userGroups } from '@/lib/db/schema/user_group';
+import { eq } from 'drizzle-orm';
+
+type NewUserGroup = {
+  name: string;
+  description: string;
+};
+
+export async function insertUserGroup(data: NewUserGroup) {
+  await db.insert(userGroups).values({
+    name: data.name,
+    description: data.description,
+  });
+}

--- a/front/src/lib/db/user_group.ts
+++ b/front/src/lib/db/user_group.ts
@@ -2,6 +2,18 @@ import { db } from '@/lib/db';
 import { userGroups } from '@/lib/db/schema/user_group';
 import { eq } from 'drizzle-orm';
 
+
+export async function selectUserGroupByName(name: string) {
+  const result = await db
+    .select()
+    .from(userGroups)
+    .where(eq(userGroups.name, name))
+    .limit(1);
+
+  return result[0] ?? null;
+}
+
+
 type NewUserGroup = {
   name: string;
   description: string;


### PR DESCRIPTION
ユーザーグループ登録機能です。

マイグレーションが必要です。
npm run db:push

グループ管理(一覧)画面から登録へ遷移する想定をしているので
今の所ボタンはなく、URLでuser_group/registerと入力する必要があります。

ユーザーグループ名はユニークにしていて、重複登録をしようとするとエラーメッセージが出ます。

今はuser_groupsテーブルのみに登録していますが、user_group_assignmentsテーブルに自分を管理者として登録する必要があります。このタスクはhttps://github.com/study-basic-hackathon/for-moku/issues/97
で進めています。