### PR TITLE
【イベント】【新規作成】イベント新規作成における画面モックを作成 #106

### DIFF
--- a/front/src/actions/event/getUserGroup.ts
+++ b/front/src/actions/event/getUserGroup.ts
@@ -1,0 +1,18 @@
+'use server';
+
+/**
+ * ユーザーグループを取得
+ * 
+ * @returns ユーザーグループの配列
+ */
+export async function getMockUserGroups() {
+  // 1秒待機
+  await new Promise(resolve => setTimeout(resolve, 1000));
+
+  // 適当なデータを返却
+  return [
+    { id: 1, name: 'グループA' },
+    { id: 2, name: 'グループB' },
+    { id: 3, name: 'グループC' }
+  ];
+}

--- a/front/src/actions/event/registerEvent.ts
+++ b/front/src/actions/event/registerEvent.ts
@@ -1,0 +1,11 @@
+'use server';
+
+/**
+ * イベントを登録
+ * 
+ * @param formData フォームデータ
+ * @returns 特になし
+ */
+export async function registerEvent(formData: FormData) {
+  console.log('Form data:', Object.fromEntries(formData));
+}

--- a/front/src/app/(withsidebar)/event/register/loading.tsx
+++ b/front/src/app/(withsidebar)/event/register/loading.tsx
@@ -1,0 +1,10 @@
+import LoadingTsxTemplate from "@/components/templates/common/LoadingTsxTemplate";
+
+/**
+ * ローディング画面(青いぐるぐるが出ます)
+ * 
+ * @returns ローディング画面
+ */
+export default function Loading() {
+  return <LoadingTsxTemplate />;
+}

--- a/front/src/app/(withsidebar)/event/register/page.tsx
+++ b/front/src/app/(withsidebar)/event/register/page.tsx
@@ -1,0 +1,10 @@
+import { getMockUserGroups } from '@/actions/event/getUserGroup';
+import EventRegisterTemplate from '@/components/templates/event/register/EventRegisterTemplate';
+
+export default async function EventRegisterPage() {
+  const userGroups = await getMockUserGroups();
+  
+  return (
+    <EventRegisterTemplate userGroups={userGroups} />
+  );
+} 

--- a/front/src/components/organisms/common/form/FormInput.tsx
+++ b/front/src/components/organisms/common/form/FormInput.tsx
@@ -1,0 +1,28 @@
+import { InputType } from "@/types/common/form";
+
+interface FormInputProps {
+  name: string;
+  type?: InputType;
+  placeholder?: string;
+  required?: boolean;
+}
+/**
+ * フォームの入力フィールド(input要素のラッパー)
+ * 
+ * @param name フィールド名
+ * @param type 入力タイプ
+ * @param placeholder プレースホルダー
+ * @param required 必須かどうか
+ * @returns 入力フィールド
+ */
+export default function FormInput({ name, type = 'text', placeholder, required }: Readonly<FormInputProps>) {
+  return (
+    <input
+      type={type}
+      name={name}
+      className="w-full border px-3 py-2 rounded"
+      placeholder={placeholder}
+      required={required}
+    />
+  );
+} 

--- a/front/src/components/organisms/common/form/FormSelect.tsx
+++ b/front/src/components/organisms/common/form/FormSelect.tsx
@@ -1,0 +1,32 @@
+interface FormSelectProps {
+  name: string;
+  placeholder?: string;
+  required?: boolean;
+  options: { value: string; label: string; }[];
+}
+
+/**
+ * フォームのセレクトボックス要素(select要素のラッパー)
+ * 
+ * @param name フィールド名
+ * @param placeholder プレースホルダー
+ * @param required 必須かどうか
+ * @param options 選択肢の配列
+ * @returns セレクトボックス要素
+ */
+export default function FormSelect({ name, placeholder, required, options }: Readonly<FormSelectProps>) {
+  return (
+    <select
+      name={name}
+      className="w-full border px-3 py-2 rounded"
+      required={required}
+    >
+      <option value="">{placeholder}</option>
+      {options.map((option) => (
+        <option key={option.value} value={option.value}>
+          {option.label}
+        </option>
+      ))}
+    </select>
+  );
+} 

--- a/front/src/components/organisms/common/form/FormTextarea.tsx
+++ b/front/src/components/organisms/common/form/FormTextarea.tsx
@@ -1,0 +1,27 @@
+interface FormTextareaProps {
+  name: string;
+  placeholder?: string;
+  required?: boolean;
+  rows?: number;
+}
+
+/**
+ * フォームのテキストエリア要素(textarea要素のラッパー)
+ * 
+ * @param name フィールド名
+ * @param placeholder プレースホルダー
+ * @param required 必須かどうか
+ * @param rows 行数
+ * @returns テキストエリア要素
+ */
+export default function FormTextarea({ name, placeholder, required, rows = 4 }: Readonly<FormTextareaProps>) {
+  return (
+    <textarea
+      name={name}
+      rows={rows}
+      className="w-full border px-3 py-2 rounded"
+      placeholder={placeholder}
+      required={required}
+    />
+  );
+} 

--- a/front/src/components/templates/common/CommonRegisterTemplate.tsx
+++ b/front/src/components/templates/common/CommonRegisterTemplate.tsx
@@ -56,7 +56,7 @@ export default function CommonRegisterTemplate<T>({ title, fields, onSubmit }: R
       <form action={onSubmit} className="space-y-4">
         {fields.map((field) => (
           <div key={field.name.toString()}>
-            <label className="block mb-1 font-medium">
+            <label className="block mb-1 font-medium" htmlFor={field.name.toString()}>
               {field.label}
               {field.required && <span className="text-red-500 ml-1">*</span>}
             </label>

--- a/front/src/components/templates/common/CommonRegisterTemplate.tsx
+++ b/front/src/components/templates/common/CommonRegisterTemplate.tsx
@@ -1,0 +1,75 @@
+import { CommonRegisterFormField } from '@/types/common/form';
+import FormInput from '@/components/organisms/common/form/FormInput';
+import FormTextarea from '@/components/organisms/common/form/FormTextarea';
+import FormSelect from '@/components/organisms/common/form/FormSelect';
+
+interface CommonRegisterTemplateProps<T> {
+  title: string;
+  fields: CommonRegisterFormField<T>[];
+  onSubmit: (formData: FormData) => Promise<void>;
+}
+
+/**
+ * どこでも使える新規登録フォームテンプレート
+ * 
+ * @param title タイトル
+ * @param fields フィールド（詳細は）
+ * @param onSubmit 送信処理
+ * @returns 登録フォームテンプレート
+ */
+export default function CommonRegisterTemplate<T>({ title, fields, onSubmit }: Readonly<CommonRegisterTemplateProps<T>>) {
+  const renderField = (field: CommonRegisterFormField<T>) => {
+    if (field.elementType === 'textarea') {
+      return (
+        <FormTextarea
+          name={field.name.toString()}
+          placeholder={field.placeholder}
+          required={field.required}
+        />
+      );
+    }
+
+    if (field.elementType === 'select') {
+      return (
+        <FormSelect
+          name={field.name.toString()}
+          placeholder={field.placeholder}
+          required={field.required}
+          options={field.options ?? []}
+        />
+      );
+    }
+
+    return (
+      <FormInput
+        name={field.name.toString()}
+        type={field.inputType}
+        placeholder={field.placeholder}
+        required={field.required}
+      />
+    );
+  };
+
+  return (
+    <div className="max-w-md mx-auto mt-10 p-4 border rounded shadow">
+      <h1 className="text-xl font-bold mb-4">{title}</h1>
+      <form action={onSubmit} className="space-y-4">
+        {fields.map((field) => (
+          <div key={field.name.toString()}>
+            <label className="block mb-1 font-medium">
+              {field.label}
+              {field.required && <span className="text-red-500 ml-1">*</span>}
+            </label>
+            {renderField(field)}
+          </div>
+        ))}
+
+        <div className="text-center">
+          <button type="submit" className="bg-blue-600 text-white px-6 py-2 rounded">
+            登録
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/front/src/components/templates/common/LoadingTsxTemplate.tsx
+++ b/front/src/components/templates/common/LoadingTsxTemplate.tsx
@@ -1,0 +1,12 @@
+/**
+ * ローディング画面(青いぐるぐるが出ます)
+ * 
+ * @returns ローディング画面
+ */
+export default function Loading() {
+  return (
+    <div className="flex justify-center items-center min-h-screen">
+      <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600"></div>
+    </div>
+  );
+} 

--- a/front/src/components/templates/event/register/EventRegisterTemplate.tsx
+++ b/front/src/components/templates/event/register/EventRegisterTemplate.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import CommonRegisterTemplate from '@/components/templates/common/CommonRegisterTemplate';
+import { EVENT_REGISTER_FORM_FIELDS } from '@/lib/event/register/constants';
+import { registerEvent } from '@/actions/event/registerEvent';
+import { useState } from 'react';
+import type { EventRegisterFormField } from '@/types/event/form';
+
+interface EventRegisterTemplateProps {
+  userGroups: { id: number; name: string; }[];
+}
+
+/**
+ * イベント登録テンプレート
+ * 
+ * @param userGroups ユーザーグループ
+ * @returns イベント登録テンプレート
+ */
+export default function EventRegisterTemplate({ userGroups }: Readonly<EventRegisterTemplateProps>) {
+  const [formFields] = useState<EventRegisterFormField[]>(() => 
+    EVENT_REGISTER_FORM_FIELDS.map(field => 
+      field.name === 'userGroupId'
+        ? {
+            ...field,
+            options: userGroups.map(group => ({
+              value: group.id.toString(),
+              label: group.name
+            }))
+          }
+        : field
+    )
+  );
+
+  return (
+    <CommonRegisterTemplate
+      title="新規イベント登録"
+      fields={formFields}
+      onSubmit={registerEvent}
+    />
+  );
+}

--- a/front/src/lib/event/register/constants.ts
+++ b/front/src/lib/event/register/constants.ts
@@ -1,0 +1,63 @@
+import { EventRegisterFormField } from '@/types/event/form'
+
+export const EVENT_REGISTER_FORM_FIELDS: EventRegisterFormField[] = [
+  {
+    name: 'name',
+    label: 'イベント名',
+    required: true,
+    elementType: 'input',
+    inputType: 'text',
+    placeholder: 'イベント名を入力してください'
+  },
+  {
+    name: 'description',
+    label: 'イベントの概要',
+    required: true,
+    elementType: 'textarea',
+    placeholder: 'イベントの概要を入力してください'
+  },
+  {
+    name: 'userGroupId',
+    label: 'イベントグループ',
+    required: true,
+    elementType: 'select',
+    placeholder: 'イベントグループを選択してください'
+  },
+  {
+    name: 'eventDate',
+    label: 'イベント日',
+    required: true,
+    elementType: 'input',
+    inputType: 'date'
+  },
+  {
+    name: 'eventStartTime',
+    label: '開始時刻',
+    required: true,
+    elementType: 'input',
+    inputType: 'time'
+  },
+  {
+    name: 'eventEndTime',
+    label: '終了時刻',
+    required: true,
+    elementType: 'input',
+    inputType: 'time'
+  },
+  {
+    name: 'eventUrl',
+    label: 'イベントの詳細URL',
+    required: false,
+    elementType: 'input',
+    inputType: 'text',
+    placeholder: 'https://example.com'
+  },
+  {
+    name: 'venueUrl',
+    label: '会場のURL',
+    required: false,
+    elementType: 'input',
+    inputType: 'text',
+    placeholder: 'https://example.com'
+  }
+];

--- a/front/src/types/common/form.ts
+++ b/front/src/types/common/form.ts
@@ -1,0 +1,37 @@
+import { InputHTMLAttributes } from "react";
+import { JSX } from "react/jsx-runtime";
+
+/**
+ * HTML要素の型(input, select, textareaとか)
+ * 
+ * @returns HTML要素の型
+ */
+export type HtmlElement = keyof JSX.IntrinsicElements;
+
+
+/**
+ * input要素のtype属性の型(text, date, timeとか)
+ * 
+ * @returns input要素のtype属性の型
+ */
+export type InputType = InputHTMLAttributes<HTMLInputElement>['type']
+
+/**
+ * 共通の登録フォームフィールド
+ * 
+ * 適切なフォームで使いたい場合には、Form用の型をジェネリクスに入れて動的に作成できます。
+ * 例：EventRegisterForm
+ * 
+ * @param T フォームの型（例：EventRegisterForm）
+ * @returns フィールド（詳細は下記）
+ */
+export type CommonRegisterFormField<T> = {
+  name: keyof T;
+  label: string;
+  required: boolean;
+  elementType: HtmlElement;
+  inputType?: InputType;
+  placeholder?: string;
+  options?: { value: string; label: string }[];
+}; 
+

--- a/front/src/types/event/form.ts
+++ b/front/src/types/event/form.ts
@@ -1,0 +1,29 @@
+import { CommonRegisterFormField } from "../common/form";
+
+/**
+ * イベント登録フォーム
+ * 
+ * @returns フォーム
+ */
+export type EventRegisterForm = {
+  // 必須項目
+  name: string;
+  description: string;
+  userGroupId: number;
+  
+  // 日時関連
+  eventDate: string;
+  eventStartTime: string;
+  eventEndTime: string;
+  
+  // URL関連
+  eventUrl?: string;
+  venueUrl?: string;
+};
+
+/**
+ * イベント登録フォームのフィールド定義の型
+ * 
+ * @returns フィールド
+ */
+export type EventRegisterFormField = CommonRegisterFormField<EventRegisterForm>;


### PR DESCRIPTION
イベント新規作成画面のモックを作っています。

検証リンク：http://localhost:3000/event/register 

 - イベント新規作成画面を準備
 - 登録画面で使える汎用的なテンプレートを用意
 - actionsはmock処理にしてしまいます。

井口さんの実装を踏襲しつつ、他のドメインに関する新規登録でも使えるように実装しています。