### PR TITLE
20250608_②ユーザ＆ユーザグループメンテナンスに関する修正 #113 コンフリクト解決(vs #107)

### DIFF
--- a/front/src/actions/user_group/registerUserGroup.ts
+++ b/front/src/actions/user_group/registerUserGroup.ts
@@ -1,12 +1,12 @@
 'use server';
 
 import { db } from '@/lib/db';
-import { insertUserGroupWithTx, selectUserGroupByName } from '@/lib/db/user_group';
-import { insertUserGroupAssignmentWithTx } from '@/lib/db/user_group_assignment';
+import { insertUserGroup, selectUserGroupByName } from '@/lib/db/user_group';
+import { insertUserGroupAssignment } from '@/lib/db/user_group_assignment';
 import { selectUserByEmail } from '@/lib/db/user';
 import { auth } from '@/lib/auth/auth';
 
-export async function registerUserGroup(
+export async function registerMyUserGroup(
   _prevState: { success: boolean; error: string },
   formData: FormData
 ): Promise<{ success: boolean; error: string }> {
@@ -15,8 +15,8 @@ export async function registerUserGroup(
     return { success: false, error: 'ログインしていません' };
   }
 
-  const name = formData.get('name')?.toString().trim();
-  const description = formData.get('description')?.toString().trim() ?? '';
+  const name = formData.get('name')?.toString();
+  const description = formData.get('description')?.toString() ?? '';
 
   if (!name) {
     return { success: false, error: 'グループ名は必須です' };
@@ -35,7 +35,7 @@ export async function registerUserGroup(
 
     await db.transaction(async (tx) => {
       // グループを作成
-      const group = await insertUserGroupWithTx(tx, {
+      const group = await insertUserGroup(tx, {
         name,
         description,
       });
@@ -45,7 +45,7 @@ export async function registerUserGroup(
       }
 
       // 作成者を admin として割り当て
-      await insertUserGroupAssignmentWithTx(tx, {
+      await insertUserGroupAssignment(tx, {
         userId: user.id,
         userGroupId: group.id,
         role: 'admin',

--- a/front/src/components/templates/user_group/UserGroupRegisterTemplate.tsx
+++ b/front/src/components/templates/user_group/UserGroupRegisterTemplate.tsx
@@ -2,7 +2,7 @@
 
 import { useActionState } from 'react';
 import { useRouter } from 'next/navigation';
-import { registerUserGroup } from '@/actions/user_group/registerUserGroup';
+import { registerMyUserGroup } from '@/actions/user_group/registerUserGroup';
 import { useEffect, useState } from 'react';
 
 export default function UserGroupRegisterTemplate() {
@@ -10,7 +10,7 @@ export default function UserGroupRegisterTemplate() {
   const [name, setName] = useState('');
   const [description, setDescription] = useState('');
   const initialState = { success: false, error: '' };
-  const [state, formAction] = useActionState(registerUserGroup, initialState);
+  const [state, formAction] = useActionState(registerMyUserGroup, initialState);
 
   useEffect(() => {
     if (state.success) {

--- a/front/src/lib/db/user_group.ts
+++ b/front/src/lib/db/user_group.ts
@@ -1,11 +1,13 @@
 import { db } from '@/lib/db';
+import { Transaction } from '@/types/db';
+import { NewUserGroup } from '@/types/user_group/schema';
 import { userGroups } from '@/lib/db/schema/user_group';
-import { and, eq, InferInsertModel } from 'drizzle-orm';
 import { userGroupAssignments } from '@/lib/db/schema/user_group_assignment';
 import { users } from '@/lib/db/schema/user';
+import {  and, eq } from 'drizzle-orm';
 
 
-export type NewUserGroup = InferInsertModel<typeof userGroups>;
+
 
 export async function selectUserGroupByName(name: string) {
   const result = await db
@@ -42,8 +44,8 @@ export async function selectAuthedUserGroupsByEmail(email: string) {
   return results?.map((e) => e.userGroup) ?? [];
 }
 
-export async function insertUserGroupWithTx(
-  tx: any, // 型注釈を省略または any にする（実際は tx に自動で正しい型が付きます）
+export async function insertUserGroup(
+  tx: Transaction,
   data: NewUserGroup
 ) {
   const [inserted] = await tx

--- a/front/src/lib/db/user_group_assignment.ts
+++ b/front/src/lib/db/user_group_assignment.ts
@@ -1,10 +1,9 @@
+import { Transaction } from '@/types/db';
 import { userGroupAssignments } from '@/lib/db/schema/user_group_assignment';
-import { InferInsertModel } from 'drizzle-orm';
+import { NewUserGroupAssignment } from '@/types/user_group_assignment/schema';
 
-export type NewUserGroupAssignment = InferInsertModel<typeof userGroupAssignments>;
-
-export async function insertUserGroupAssignmentWithTx(
-  tx: any,
+export async function insertUserGroupAssignment(
+  tx: Transaction,
   data: NewUserGroupAssignment
 ) {
   await tx.insert(userGroupAssignments).values(data);

--- a/front/src/types/db.ts
+++ b/front/src/types/db.ts
@@ -1,0 +1,7 @@
+// src/types/db.ts
+import { PgTransaction } from 'drizzle-orm/pg-core';
+import { NodePgQueryResultHKT } from 'drizzle-orm/node-postgres';
+import { ExtractTablesWithRelations } from 'drizzle-orm';
+import * as schema from '@/lib/db/schema';
+
+export type Transaction = PgTransaction<NodePgQueryResultHKT, typeof schema, ExtractTablesWithRelations<typeof schema>>;

--- a/front/src/types/user_group/schema.ts
+++ b/front/src/types/user_group/schema.ts
@@ -1,0 +1,4 @@
+import { userGroups } from '@/lib/db/schema/user_group';
+import { InferInsertModel } from 'drizzle-orm';
+
+export type NewUserGroup = InferInsertModel<typeof userGroups>;

--- a/front/src/types/user_group_assignment/schema.ts
+++ b/front/src/types/user_group_assignment/schema.ts
@@ -1,0 +1,4 @@
+import { userGroupAssignments } from '@/lib/db/schema/user_group_assignment';
+import { InferInsertModel } from 'drizzle-orm';
+
+export type NewUserGroupAssignment = InferInsertModel<typeof userGroupAssignments>;


### PR DESCRIPTION
コンフリクトが起きていたので、feature/#103と直近の修正がコンフリクトしていたので、新たにブランチ＆リクエストを作り直しました。


山下のコメント：
https://github.com/study-basic-hackathon/for-moku/pull/102

```
withTxとついているメソッド名からtxを削除(基本的に、更新系はトランザクション境界内で使うものなので)
トランザクションの型をanyで誤魔化すのはダメです(TypeScriptで書く意味がないので、やめましょう)
descriptionやnameにtrim()はいるのか？(改行や空白が使えなくなります)
typeは基本的にtypesディレクトリに(すでにいくつかの型を放り込んでいるので)
一部関数の命名について、registerUserGroup→registerMyUserGroup
関数のコメントは極力書いてください。（何が引数で何ができるのかをきちんと書いてほしいです。AIでもいいので）
```