### PR TITLE
【イベント】【間取り編集】画像の作成＋JSONを作成するロジックを準備 #128

### DIFF
--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -19,6 +19,7 @@
         "@radix-ui/react-slot": "^1.2.3",
         "@radix-ui/react-tooltip": "^1.2.7",
         "@types/react-color": "^3.0.13",
+        "canvas": "^3.1.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "dotenv": "^16.5.0",
@@ -3790,6 +3791,35 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -3810,6 +3840,29 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
       }
     },
     "node_modules/buffer-from": {
@@ -3904,6 +3957,19 @@
           "url": "https://github.com/sponsors/ai"
         }
       ]
+    },
+    "node_modules/canvas": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/canvas/-/canvas-3.1.0.tgz",
+      "integrity": "sha512-tTj3CqqukVJ9NgSahykNwtGda7V33VLObwrHfzT0vqJXu7J4d4C/7kQQW3fOEGDfZZoILPut5H00gOjyttPGyg==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "node-addon-api": "^7.0.0",
+        "prebuild-install": "^7.1.1"
+      },
+      "engines": {
+        "node": "^18.12.0 || >= 20.9.0"
+      }
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -4096,6 +4162,28 @@
         }
       }
     },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -4140,7 +4228,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.4.tgz",
       "integrity": "sha512-3UDv+G9CsCKO1WKMGw9fwq/SWJYbI0c5Y7LU1AXYoDdbhE2AHQ6N6Nb34sG8Fj7T5APy8qXDCKuuIHd1BR0tVA==",
-      "devOptional": true,
       "engines": {
         "node": ">=8"
       }
@@ -4335,6 +4422,14 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
     },
     "node_modules/enhanced-resolve": {
       "version": "5.18.1",
@@ -4991,6 +5086,14 @@
       "integrity": "sha512-Gs6RLjzlLRdT8X9ZipJdIZI/Y6/HhRLyq9RdDlCsnpxr/+Nn6bU2EFGuC94GjxqhM+Nmij2Vcq98yoHrU8uNFQ==",
       "license": "MIT"
     },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -5120,6 +5223,11 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -5247,6 +5355,11 @@
       "funding": {
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
+    },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw=="
     },
     "node_modules/glob-parent": {
       "version": "6.0.2",
@@ -5399,6 +5512,25 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -5432,6 +5564,16 @@
       "engines": {
         "node": ">=0.8.19"
       }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
     },
     "node_modules/internal-slot": {
       "version": "1.1.0",
@@ -6288,6 +6430,17 @@
         "node": ">=8.6"
       }
     },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -6304,7 +6457,6 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -6345,6 +6497,11 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -6367,6 +6524,11 @@
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
+    },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA=="
     },
     "node_modules/napi-postinstall": {
       "version": "0.2.4",
@@ -6495,6 +6657,22 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/node-abi": {
+      "version": "3.75.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.75.0.tgz",
+      "integrity": "sha512-OhYaY5sDsIka7H7AtijtI9jwGYLyl29eQn/W623DiN/MIv5sUqc4g7BIDThX+gb7di9f6xK02nkp8sdfFWZLTg==",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/node-addon-api": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
+      "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ=="
+    },
     "node_modules/oauth4webapi": {
       "version": "3.5.1",
       "resolved": "https://registry.npmjs.org/oauth4webapi/-/oauth4webapi-3.5.1.tgz",
@@ -6615,6 +6793,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dependencies": {
+        "wrappy": "1"
       }
     },
     "node_modules/optionator": {
@@ -6925,6 +7111,31 @@
         "preact": ">=10"
       }
     },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -6942,6 +7153,15 @@
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
         "react-is": "^16.13.1"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.2.tgz",
+      "integrity": "sha512-tUPXtzlGM8FE3P0ZL6DVs/3P58k9nk8/jZeQCurTJylQA8qFYzHFfhBJkuqyE0FifOsQ0uKWekiZ5g8wtr28cw==",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
       }
     },
     "node_modules/punycode": {
@@ -6972,6 +7192,28 @@
           "url": "https://feross.org/support"
         }
       ]
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/rc/node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/react": {
       "version": "19.1.0",
@@ -7130,6 +7372,19 @@
         "lodash": "^4.0.1"
       }
     },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
@@ -7262,6 +7517,25 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
     "node_modules/safe-push-apply": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/safe-push-apply/-/safe-push-apply-1.0.0.tgz",
@@ -7304,7 +7578,6 @@
       "version": "7.7.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
       "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
-      "devOptional": true,
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -7491,6 +7764,49 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
     "node_modules/simple-swizzle": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
@@ -7550,6 +7866,14 @@
       "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
       "engines": {
         "node": ">=10.0.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/string.prototype.includes": {
@@ -7768,6 +8092,37 @@
         "node": ">=18"
       }
     },
+    "node_modules/tar-fs": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.3.tgz",
+      "integrity": "sha512-090nwYJDmlhwFwEW3QQl+vaNnxsO2yVsd45eTKRBzSzu+hlb1w2K9inVq5b0ngXuLVqQ4ApvsUHHnu/zQNkWAg==",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-fs/node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/tinycolor2": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.6.0.tgz",
@@ -7874,6 +8229,17 @@
       },
       "optionalDependencies": {
         "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/tw-animate-css": {
@@ -8102,6 +8468,11 @@
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -8210,6 +8581,11 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
     },
     "node_modules/xtend": {
       "version": "4.0.2",

--- a/front/package.json
+++ b/front/package.json
@@ -21,6 +21,7 @@
     "@radix-ui/react-slot": "^1.2.3",
     "@radix-ui/react-tooltip": "^1.2.7",
     "@types/react-color": "^3.0.13",
+    "canvas": "^3.1.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "dotenv": "^16.5.0",

--- a/front/src/actions/event/saveVenueInfo.ts
+++ b/front/src/actions/event/saveVenueInfo.ts
@@ -1,0 +1,69 @@
+'use server';
+
+import { auth } from "@/lib/auth/auth";
+import { TextState } from "@/types/event/state";
+import { generateImage } from "@/lib/event/venueedit/nodeCanvasControl";  
+
+/**
+ * 会場の情報を永続化するためのパラメータ
+ * 
+ * @param numPixel ピクセル数
+ * @param encodedPixelColor ピクセルの色状態
+ * @param encodedCircleColor 円の色状態
+ * @param textState テキストの状態
+ * @param pixelSize ピクセルサイズ
+ * @param gridColor グリッドの色
+ * @param gridWidth グリッドの幅
+ */
+interface Props {
+  numPixel: number
+  encodedPixelColor: {[k: string]: {x: number, y: number}[]}
+  encodedCircleColor: {[k: string]: {x: number, y: number}[]}
+  textState: TextState[]
+  pixelSize?: number
+  gridColor?: string
+  gridWidth?: number
+}
+
+/**
+ * 会場の情報を永続化する
+ * 
+ * @param props: 会場の情報
+ * @returns 保存された会場の情報
+ */
+export async function saveVenueInfo({
+  numPixel,
+  encodedPixelColor,
+  encodedCircleColor,
+  textState,
+  pixelSize = 30,
+  gridColor = '#CCCCCC',
+  gridWidth = 1
+}: Props) {
+  const session = await auth();
+  if (!session) {
+    throw new Error('認証が必要です');
+  }
+
+  // PNG形式のバッファを生成
+  const imageBuffer = generateImage({
+    numPixel,
+    encodedPixelColor,
+    encodedCircleColor,
+    textState,
+    pixelSize,
+    gridColor,
+    gridWidth
+  });
+  
+  // TODO: 画像を保存する
+  // 仮の実装として、Base64形式に変換して返す
+  const base64Data = imageBuffer.toString('base64');
+  console.log(base64Data)
+  const imageUrl = `data:image/png;base64,${base64Data}`;
+
+  return {
+    imageUrl,
+    message: '画像が生成されました'
+  };
+} 

--- a/front/src/components/templates/event/venueedit/VenueActionHeader.tsx
+++ b/front/src/components/templates/event/venueedit/VenueActionHeader.tsx
@@ -6,13 +6,17 @@ interface Props {
   handleZoomOut: () => void
   numPixel: number
   setNumPixel: (n: number) => void
+  saveAction?: () => void
+  isPending?: boolean
 }
 
 export default function VenueActionHeader({ 
   handleZoomIn, 
   handleZoomOut,
   numPixel,
-  setNumPixel 
+  setNumPixel,
+  saveAction,
+  isPending
 }: Readonly<Props>) {
 
   const handlePixelChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -65,8 +69,12 @@ export default function VenueActionHeader({
           <button className="px-4 py-2 bg-red-500 text-white rounded hover:bg-red-600">
             取り消し
           </button>
-          <button className="px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600">
-            保存
+          <button 
+            className="px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600"
+            onClick={saveAction}
+            disabled={isPending}
+          >
+            {isPending ? '保存中...' : '保存'}
           </button>
         </div>
       </div>

--- a/front/src/components/templates/event/venueedit/VenueEditorTemplate.tsx
+++ b/front/src/components/templates/event/venueedit/VenueEditorTemplate.tsx
@@ -38,6 +38,8 @@ export default function VenueEditorTemplate() {
     setIsTextDialogOpen,
     setCurrentText,
     handleTextAdd,
+    saveImageAction,
+    isPendingForSave
   } = useCanvasDraw({
     selectedColor,
     selectedTool,
@@ -51,6 +53,8 @@ export default function VenueEditorTemplate() {
         setNumPixel={setNumPixel}
         handleZoomIn={handleZoomIn}
         handleZoomOut={handleZoomOut}
+        saveAction={saveImageAction}
+        isPending={isPendingForSave}
       />
       <div className="p-5">
         <div className="grid grid-cols-1 lg:grid-cols-8 xl:grid-cols-12 gap-4">

--- a/front/src/hooks/event/venueedit/image/useImageAction.ts
+++ b/front/src/hooks/event/venueedit/image/useImageAction.ts
@@ -1,0 +1,52 @@
+import { useCallback, useState } from 'react'
+import { Color } from 'react-color'
+import { TextState } from '@/types/event/state'
+import { saveVenueInfo } from '@/actions/event/saveVenueInfo'
+import { downloadVenueJson, encodeVenue } from '@/lib/event/venueedit/encode'
+
+interface Props {
+  numPixel: number
+  pixelColorState: (Color | null)[][]
+  circleColorState: (Color | null)[][]
+  textState: TextState[]
+}
+/**
+ * 会場の画像に関連するアクションを管理するフック
+ * 
+ * @param props 会場の情報
+ * @returns 会場の情報を永続化する関数と、永続化中かどうかのフラグ
+ */
+export const useImageAction = (props: Props) => {
+  const { numPixel, pixelColorState, circleColorState, textState } = props
+  const [isPendingForSave, setIsPendingForSave] = useState(false)
+
+  const saveImageAction = useCallback(async () => {
+    try {
+      setIsPendingForSave(true)
+      const encoded = encodeVenue(numPixel, pixelColorState, circleColorState, textState)
+      await Promise.all([
+        // TODO: 本番リリース前に必ず削除
+        // デバッグ用のJSONファイルをダウンロード
+        downloadVenueJson(numPixel, pixelColorState, circleColorState, textState),  
+
+        // 画像データを保存&永続化
+        saveVenueInfo({
+          numPixel,
+          encodedPixelColor: encoded.encodedPixelColor,
+          encodedCircleColor: encoded.encodedCircleColor,
+          textState: encoded.textState,
+          pixelSize: 50,
+          gridColor: '#CCCCCC',
+          gridWidth: 1
+        })
+      ])
+    } finally {
+      setIsPendingForSave(false)
+    }
+  }, [numPixel, pixelColorState, circleColorState, textState])
+
+  return {
+    saveImageAction,
+    isPendingForSave
+  }
+} 

--- a/front/src/hooks/event/venueedit/useCanvasDraw.ts
+++ b/front/src/hooks/event/venueedit/useCanvasDraw.ts
@@ -6,6 +6,7 @@ import { DEFAULT_NUM_PIXEL } from '@/lib/event/venueedit/constants'
 import { useToolSelect } from '@/hooks/event/venueedit/tool/useToolSelect'
 import { TextState } from '@/types/event/state'
 import { useDrawingState } from '@/hooks/event/venueedit/useDrawingState'
+import { useImageAction } from './image/useImageAction'
 
 /**
  * キャンバスの描画を管理するフックのProps
@@ -42,7 +43,6 @@ export const useCanvasDraw = ({
   const [textState, setTextState] = useState<TextState[]>([])
   const [isDialogModalOpen, setIsDialogModalOpen] = useState(false)
 
-
   const { canvasRef, startDrawing, endDrawing } = useDrawingState({
     numPixel,
     pixelColorState,
@@ -52,6 +52,13 @@ export const useCanvasDraw = ({
     setCircleColorState,
     setTextState,
     isDialogModalOpen
+  })
+
+  const {saveImageAction, isPendingForSave} = useImageAction({
+    numPixel,
+    pixelColorState,
+    circleColorState,
+    textState
   })
 
   const { canDraw: toolCanDraw,
@@ -102,5 +109,7 @@ export const useCanvasDraw = ({
     textPosition,
     setTextPosition,
     handleTextAdd,
+    saveImageAction,
+    isPendingForSave
   }
 } 

--- a/front/src/lib/event/venueedit/decode.ts
+++ b/front/src/lib/event/venueedit/decode.ts
@@ -1,0 +1,47 @@
+import { Color } from "react-color"
+import { TextState } from "@/types/event/state"
+
+/**
+ * 復元された会場の情報
+ */
+interface DecodedVenue {
+  numPixel: number
+  pixelColorState: (Color | null)[][]
+  circleColorState: (Color | null)[][]
+  textState: TextState[]
+}
+
+/**
+ * 会場の情報を復元する
+ * @param json 会場の情報
+ * @returns 復元された会場の情報
+ */
+export function decodeVenue(json: string): DecodedVenue {
+  const data = JSON.parse(json)
+  const { numPixel, encodedPixelColor, encodedCircleColor, textState } = data
+
+  // 空の二次元配列を作成
+  const pixelColorState: (Color | null)[][] = Array(numPixel).fill(null).map(() => Array(numPixel).fill(null))
+  const circleColorState: (Color | null)[][] = Array(numPixel).fill(null).map(() => Array(numPixel).fill(null))
+
+  // ピクセルカラーを復元
+  Object.entries(encodedPixelColor).forEach(([color, positions]) => {
+    (positions as {x: number, y: number}[]).forEach(({x, y}) => {
+      pixelColorState[y][x] = color as Color
+    })
+  })
+
+  // 円のカラーを復元
+  Object.entries(encodedCircleColor).forEach(([color, positions]) => {
+    (positions as {x: number, y: number}[]).forEach(({x, y}) => {
+      circleColorState[y][x] = color as Color
+    })
+  })
+
+  return {
+    numPixel,
+    pixelColorState,
+    circleColorState,
+    textState
+  }
+} 

--- a/front/src/lib/event/venueedit/encode.ts
+++ b/front/src/lib/event/venueedit/encode.ts
@@ -1,0 +1,93 @@
+import { TextState } from "@/types/event/state"
+import { Color } from "react-color"
+import { saveVenueJson } from "@/actions/event/saveVenueJson"
+
+/**
+ * エンコードされた会場データのインターフェース
+ */
+interface EncodedVenue {
+  numPixel: number
+  encodedPixelColor: {[k: string]: {x: number, y: number}[]}
+  encodedCircleColor: {[k: string]: {x: number, y: number}[]}
+  textState: TextState[]
+}
+
+/**
+ * マトリックスの要素を表すインターフェース
+ */
+interface MatrixElement {
+  value: Color;
+  x: number;
+  y: number;
+}
+
+/**
+ * マトリックスをフラット化し、nullを除去して色ごとに座標をグループ化する
+ * @param matrix 2次元の色マトリックス
+ * @returns 色をキー、座標の配列を値とするMap
+ */
+function flattenAndRemoveNull(matrix: (Color | null)[][]): Map<string, {x: number, y: number}[]> {
+  const flatten =  matrix.flatMap((row, y) => 
+    row.map((value, x) => ({ value, x, y }))
+      .filter(({ value }) => value !== null) as MatrixElement[]
+  )
+
+  const colorMap = flatten.reduce((acc, element) => {
+    const color = element?.value?.toString()
+    if (!acc.has(color)) {
+      acc.set(color, [])
+    }
+    acc.get(color)?.push({x: element.x, y: element.y})
+    return acc
+  }, new Map<string, {x: number, y: number}[]>()
+  )
+
+  return colorMap
+}
+
+/**
+ * 会場データをエンコードする
+ * @param numPixel ピクセル数
+ * @param pixelColorState ピクセルの色状態
+ * @param circleColorState 円の色状態
+ * @param textState テキストの状態
+ * @returns エンコードされた会場データ
+ */
+export function encodeVenue(numPixel: number, pixelColorState: (Color | null)[][], circleColorState: (Color | null)[][], textState: TextState[]) :EncodedVenue {
+  const encodedPixelColor = Object.fromEntries(flattenAndRemoveNull(pixelColorState))
+  const encodedCircleColor = Object.fromEntries(flattenAndRemoveNull(circleColorState))
+  return {
+    numPixel,
+    encodedPixelColor,
+    encodedCircleColor,
+    textState
+  }
+}
+
+/**
+ * 会場データをJSONとしてダウンロードする
+ * @param numPixel ピクセル数
+ * @param pixelColorState ピクセルの色状態
+ * @param circleColorState 円の色状態
+ * @param textState テキストの状態
+ */
+export async function downloadVenueJson(numPixel: number, pixelColorState: (Color | null)[][], circleColorState: (Color | null)[][], textState: TextState[]) {
+  const encoded = encodeVenue(numPixel, pixelColorState, circleColorState, textState)
+  const jsonString = JSON.stringify(encoded)
+
+  // JSONを圧縮
+  const compressed = jsonString
+    .replace(/\s+/g, '')  // 空白を削除
+    .replace(/,}/g, '}')  // 末尾のカンマを削除
+    .replace(/,]/g, ']');  // 配列の末尾のカンマを削除
+
+  const blob = new Blob([compressed], { type: 'application/json' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = `venue_${new Date().toISOString()}.json`;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+}

--- a/front/src/lib/event/venueedit/nodeCanvasControl.ts
+++ b/front/src/lib/event/venueedit/nodeCanvasControl.ts
@@ -1,0 +1,143 @@
+import { TextState } from "@/types/event/state"
+import { createCanvas, CanvasRenderingContext2D } from 'canvas'
+
+interface Props {
+  numPixel: number
+  encodedPixelColor: {[k: string]: {x: number, y: number}[]}
+  encodedCircleColor: {[k: string]: {x: number, y: number}[]}
+  textState: TextState[]
+  pixelSize?: number
+  backgroundColor?: string
+  gridColor?: string
+  gridWidth?: number
+}
+
+function drawColoredSquare(
+  ctx: CanvasRenderingContext2D,
+  startX: number,
+  startY: number,
+  cellSize: number,
+  width: number,
+  height: number,
+  color: string
+) {
+  ctx.fillStyle = color
+  ctx.fillRect(startX * cellSize, startY * cellSize, width * cellSize, height * cellSize)
+}
+
+function drawText(
+  ctx: CanvasRenderingContext2D,
+  cellSize: number,
+  text: TextState
+) {
+  const startX = text.startX
+  const startY = text.startY
+  const endX = text.endX
+  const endY = text.endY
+  const textColor = text.textColor
+  const textLength = text.text.length
+
+  const fontSize = Math.min(((Math.abs(endX - startX) + 1) * cellSize)/textLength, (Math.abs(endY - startY)+1) * cellSize)
+  ctx.fillStyle = textColor.toString()
+  ctx.font = `${fontSize}px sans-serif`
+  
+  const x = ((startX + endX) / 2 + 0.5) * cellSize
+  const y = ((startY + endY) / 2 + 0.5) * cellSize
+
+  ctx.textAlign = 'center'
+  ctx.textBaseline = 'middle'
+  ctx.fillText(text.text, x, y)
+}
+
+function drawCircle(
+  ctx: CanvasRenderingContext2D,
+  cellX: number,
+  cellY: number,
+  cellSize: number,
+  color: string
+) {
+  const centerX = cellX * cellSize + cellSize / 2
+  const centerY = cellY * cellSize + cellSize / 2
+  const radius = (cellSize / 2) * 0.8
+
+  ctx.fillStyle = color
+  ctx.beginPath()
+  ctx.arc(centerX, centerY, radius, 0, Math.PI * 2)
+  ctx.fill()
+}
+
+function drawCellGrid(
+  ctx: CanvasRenderingContext2D,
+  cellX: number,
+  cellY: number,
+  cellSize: number
+) {
+  ctx.strokeStyle = '#777777'
+  const lineWidth = cellSize / 10
+  ctx.lineWidth = lineWidth
+  const padding = lineWidth / 2
+  ctx.beginPath()
+  ctx.moveTo(cellX * cellSize + padding, cellY * cellSize + padding)
+  ctx.lineTo((cellX + 1) * cellSize - padding, cellY * cellSize + padding)
+  ctx.lineTo((cellX + 1) * cellSize - padding, (cellY + 1) * cellSize - padding)
+  ctx.lineTo(cellX * cellSize + padding, (cellY + 1) * cellSize - padding)
+  ctx.closePath()
+  ctx.stroke()
+}
+
+/**
+ * 会場の画像を生成する(@サーバー側で使用)
+ * 
+ * @param props 会場の情報
+ * @returns 会場の画像(バッファ)
+ */
+export function generateImage({
+  numPixel,
+  encodedPixelColor,
+  encodedCircleColor,
+  textState,
+  pixelSize = 30,
+  backgroundColor = '#FFFFFF',
+}: Props): Buffer {
+  const canvasSize = numPixel * pixelSize
+  const canvas = createCanvas(canvasSize, canvasSize)
+  const ctx = canvas.getContext('2d') as CanvasRenderingContext2D
+
+  // 背景を塗りつぶし
+  ctx.fillStyle = backgroundColor
+  ctx.fillRect(0, 0, canvasSize, canvasSize)
+
+  // ピクセルを描画
+  for (const [color, positions] of Object.entries(encodedPixelColor)) {
+    for (const {x, y} of positions) {
+      ctx.fillStyle = color
+      ctx.fillRect(x * pixelSize, y * pixelSize, pixelSize, pixelSize)
+      drawCellGrid(ctx, x, y, pixelSize)
+    }
+  }
+
+  // 円を描画
+  for (const [color, positions] of Object.entries(encodedCircleColor)) {
+    for (const {x, y} of positions) {
+      drawCircle(ctx, x, y, pixelSize, color)
+    }
+  }
+
+  // テキストを描画
+  for (const text of textState) {
+    if (text.backgroundColor != null) {
+      drawColoredSquare(
+        ctx,
+        text.startX,
+        text.startY,
+        pixelSize,
+        text.endX - text.startX + 1,
+        text.endY - text.startY + 1,
+        text.backgroundColor.toString()
+      )
+    }
+    drawText(ctx, pixelSize, text)
+  }
+
+  return canvas.toBuffer('image/png')
+} 


### PR DESCRIPTION
State(Reactで管理しているピクセル情報やテキストの情報)から画像とJSONを生成するロジックを準備しました。
今のブランチ限定で、JSONがダウンロードされる仕様になっています。まだ外部への永続化はできません。

検証URL: http://localhost:3000/event/venueedit/sample

- package.jsonとpackage-lock.jsonにcanvasパッケージを追加
- 保存ボタンの押下によりイベントが実行されるように
- 間取りの保存については、useImageActionフックを経由してTemplate上で使えるようにしている
- 保存系は現状スケルトン
- stateとjsonを相互に変換できるロジックをlib側に準備
- jsonから画像を生成するロジックも用意