### PR TITLE
【イベント】【詳細】イベント詳細画面においてDBから値を取得し表示する #30

### DIFF
--- a/front/src/actions/event/eventview.ts
+++ b/front/src/actions/event/eventview.ts
@@ -1,0 +1,41 @@
+import { selectEventById } from "@/lib/db/event";
+import { selectUserGroupById } from "@/lib/db/user_group";
+import { EventViewViewModel } from "@/types/event/viewmodel";
+import { formatDateTimeYYYYMMDDHHMMJPN } from "@/lib/util/date";
+
+/**
+ * イベントIDからイベント詳細ビューモデルを取得
+ * 
+ * @param eventId イベントID
+ * @returns イベント詳細のビューモデル
+ */
+export async function getEventViewViewModel(eventId: number): Promise<EventViewViewModel | null> {
+  // イベントを取得
+  const event = await selectEventById(eventId);
+  
+  // イベントが見つからない場合はエラーを返す
+  if (!event) {
+    return null;
+  }
+
+  // ユーザーグループを取得
+  const userGroup = await selectUserGroupById(event.userGroupId);
+  if (!userGroup) {
+    return null;
+  }
+
+  // イベント詳細ビューモデルを作成
+  return {
+    eventId: event.id,
+    eventName: event.name,
+    description: event.description ?? '',
+    eventShareLinkUrl: `/room/${event.id}`,
+    eventStartDateTime: formatDateTimeYYYYMMDDHHMMJPN(event.startDateTime),
+    eventEndDateTime: formatDateTimeYYYYMMDDHHMMJPN(event.endDateTime),
+    eventUrl: event.eventUrl ?? undefined,
+    venueUrl: event.venueUrl ?? undefined,
+    userGroupName: userGroup.name,
+    userGroupUrl: `/user_group/${userGroup.id}`,
+    imageUrl: event.imageUrl ?? undefined
+  };
+}

--- a/front/src/app/(withsidebar)/event/eventedit/[eventId]/page.tsx
+++ b/front/src/app/(withsidebar)/event/eventedit/[eventId]/page.tsx
@@ -1,0 +1,7 @@
+export default function EventEditPage() {
+  return (
+    <div>
+      EventEdit
+    </div>
+  )
+} 

--- a/front/src/app/(withsidebar)/event/view/[eventId]/page.tsx
+++ b/front/src/app/(withsidebar)/event/view/[eventId]/page.tsx
@@ -1,6 +1,6 @@
 import EventViewTemplate from "@/components/templates/event/view/EventViewTemplate"
-import { selectEventById } from "@/lib/db/event";
 import { notFound } from "next/navigation";
+import { getEventViewViewModel } from "@/actions/event/eventview";
 
 export default async function EventViewPage({
   params,
@@ -17,14 +17,13 @@ export default async function EventViewPage({
     return notFound();
   }
 
-  const event = await selectEventById(eventIdNumber);
+  // イベント詳細画面用のビューモデルを取得
+  const eventViewModel = await getEventViewViewModel(eventIdNumber);
   
-  // イベントが見つからない場合はエラーを返す
-  if (!event) {
+  if (!eventViewModel) {
     return notFound();
   }
 
-  console.log(event);
-  
-  return <EventViewTemplate/>
+  // イベント詳細画面を表示
+  return <EventViewTemplate event={eventViewModel} />
 } 

--- a/front/src/app/(withsidebar)/event/view/sample/page.tsx
+++ b/front/src/app/(withsidebar)/event/view/sample/page.tsx
@@ -1,5 +1,23 @@
 import EventViewTemplate from "@/components/templates/event/view/EventViewTemplate"
+import { getEventViewViewModel } from "@/actions/event/eventview";
+import { notFound } from "next/navigation";
 
-export default function EventViewPage() {
-  return <EventViewTemplate />
+export default async function EventViewPage({
+  params,
+}: {
+  params: Promise<{ eventId: string }>;
+}) {
+  // サンプルページなので１で固定
+  const eventId = 1
+
+  // イベント詳細画面用のビューモデルを取得
+  const eventViewModel = await getEventViewViewModel(eventId);
+
+  // イベント詳細画面用のビューモデルが取得できない場合はエラーを返す
+  if (!eventViewModel) {
+    return notFound();
+  }
+
+  // イベント詳細画面を表示
+  return <EventViewTemplate event={eventViewModel} />
 } 

--- a/front/src/app/event/venueedit/[eventId]/page.tsx
+++ b/front/src/app/event/venueedit/[eventId]/page.tsx
@@ -1,0 +1,7 @@
+import VenueEditorTemplate from "@/components/templates/event/venueedit/VenueEditorTemplate"
+
+export default async function Events() {
+  return (
+    <VenueEditorTemplate />
+  );
+}

--- a/front/src/components/templates/event/view/EventView.tsx
+++ b/front/src/components/templates/event/view/EventView.tsx
@@ -2,43 +2,13 @@
 import { eventContainerClass } from "@/styles/event";
 import CommonViewIconUnitList from "@/components/organisms/common/view/CommonViewIconUnitList";
 import ViewIconUnit from "@/components/organisms/common/view/ViewIconUnit";
-import { eventSample } from "@/actions/event/sample";
-import { CommonViewIconUnit } from "@/types/common/view";
+import { EventViewViewModel } from "@/types/event/viewmodel";
+import { useEventViewIconUnits } from "@/hooks/event/view/useEventViewIconUnits";
+import { useEventSample } from "@/hooks/event/view/useEventSample";
 
-export const eventViewIconUnits: CommonViewIconUnit[] = [
-  {
-    name: "participants",
-    iconName: "Users",
-    description: "ユーザーグループ",
-    href: "#",
-    descriptionClassName: "text-xl font-bold",
-  },
-  {
-    name: "startTime",
-    iconName: "Calendar",
-    description: "2024年5月1日 10:00",
-    descriptionClassName: "text-lg font-bold",
-  },
-  {
-    name: "endTime",
-    description: "　　　〜　2024年5月1日 18:00",
-    descriptionClassName: "text-lg font-bold",
-  },
-  {
-    name: "venueLink",
-    iconName: "Link",
-    description: "会場リンク",
-    descriptionClassName: "text-md font-bold",
-    href: "#",
-  },
-  {
-    name: "eventLink",
-    iconName: "Link",
-    description: "イベントリンク",
-    descriptionClassName: "text-md font-bold",
-    href: "#",
-  }
-];
+interface Props {
+  event: EventViewViewModel;
+}
 
 /**
  * イベントのビュー
@@ -50,7 +20,12 @@ export const eventViewIconUnits: CommonViewIconUnit[] = [
  * 
  * 使用例:
  */
-export default function EventView() {
+export default function EventView({ event }: Readonly<Props>) {
+  // アイコンユニットリストを作成
+  const eventViewIconUnits = useEventViewIconUnits(event);
+  // イベントサンプル生成のコールバックを取得
+  const handleEventSample = useEventSample();
+
   return (
     <div className={eventContainerClass}>
       <div className="flex justify-end items-center w-full gap-x-2">
@@ -58,7 +33,7 @@ export default function EventView() {
           name: "edit",
           iconName: "Pencil",
           description: "編集",
-          href: "/event/eventedit/sample",
+          href: `/event/eventedit/${event.eventId}`,
           iconClassName: "w-6 h-6",
         }} />
         <ViewIconUnit unit={{
@@ -66,7 +41,7 @@ export default function EventView() {
           iconName: "Copy",
           description: "イベントコピー",
           iconClassName: "w-6 h-6",
-          onClick: eventSample,
+          onClick: handleEventSample,
         }} />
       </div>
       <CommonViewIconUnitList units={eventViewIconUnits} />

--- a/front/src/components/templates/event/view/EventViewHeader.tsx
+++ b/front/src/components/templates/event/view/EventViewHeader.tsx
@@ -1,39 +1,11 @@
-'use client';
-
 import { eventContainerClass } from "@/styles/event";
 import CommonViewIconUnitList from "@/components/organisms/common/view/CommonViewIconUnitList";
-import { CommonViewIconUnit } from "@/types/common/view";
+import { EventViewViewModel } from "@/types/event/viewmodel";
+import { useEventViewHeaderIconUnits } from "@/hooks/event/view/useEventViewHeaderIconUnits";
 
-/**
- * イベントのビューのヘッダーのアイコンユニットリスト
- * 
- * このコンポーネントは、イベント詳細画面のヘッダーのアイコンリストを表示します
- * 
- * スタイルのカスタマイズ:
- * - eventContainerClass: コンテナのスタイルをカスタマイズします（例：背景色、パディング、ホバー効果など）
- * 
- */
-export const eventViewHeaderIconUnits: CommonViewIconUnit[] = [
-  {
-    name: "イベント名",
-    iconName: "Megaphone",
-    description: "サンプルイベント",
-    descriptionClassName: "text-2xl font-bold",
-  },
-  {
-    name: "共有リンク",
-    iconName: "Link2",
-    description: "部屋のリンク",
-    href: "/room/sample",
-    descriptionClassName: "text-xl font-bold",
-  },
-  {
-    name: "description",
-    iconName: "FileText",
-    description: "オフラインで開催予定のイベントです",
-    descriptionClassName: "text-lg font-bold",
-  },
-];
+interface Props {
+  event: EventViewViewModel;
+}
 
 /**
  * イベントのビューのヘッダー
@@ -45,7 +17,9 @@ export const eventViewHeaderIconUnits: CommonViewIconUnit[] = [
  * 
  * 使用例:
  */
-export default function EventViewHeader() {
+export default function EventViewHeader({ event }: Readonly<Props>) {
+  // アイコンユニットリストを作成
+  const eventViewHeaderIconUnits = useEventViewHeaderIconUnits(event);
 
   return (
     <div className={eventContainerClass}>

--- a/front/src/components/templates/event/view/EventViewTemplate.tsx
+++ b/front/src/components/templates/event/view/EventViewTemplate.tsx
@@ -2,13 +2,20 @@ import EventView from "@/components/templates/event/view/EventView"
 import VenueView from "@/components/templates/event/view/VenueView"
 import EventViewHeader from "@/components/templates/event/view/EventViewHeader"
 import TwoColumnTemplate from "@/components/templates/common/TwoColumnTemplate" 
+import { EventViewViewModel } from "@/types/event/viewmodel";
 
-export default function EventViewTemplate() {
+interface Props {
+  event: EventViewViewModel;
+}
+
+export default function EventViewTemplate({ event }: Readonly<Props>) {
+
+  // イベント詳細画面は、ヘッダー、左コンテンツ、右コンテンツの3つのコンポーネントで構成されるのでTwoColumnTemplateを使っています
   return (
     <TwoColumnTemplate
-      header={<EventViewHeader />}
-      leftContent={<VenueView />}
-      rightContent={<EventView />}
+      header={<EventViewHeader event={event} />}
+      leftContent={<VenueView event={event} />}
+      rightContent={<EventView event={event} />}
     />
   )
 } 

--- a/front/src/components/templates/event/view/VenueView.tsx
+++ b/front/src/components/templates/event/view/VenueView.tsx
@@ -1,7 +1,12 @@
 import ViewIconUnit from "@/components/organisms/common/view/ViewIconUnit";
 import { eventContainerClass } from "@/styles/event";
+import { EventViewViewModel } from "@/types/event/viewmodel";
 
-/**
+interface Props {
+  event: EventViewViewModel;
+}
+
+  /**
  * イベントの会場のビュー
  * 
  * このコンポーネントは、イベント詳細画面の会場のビューを表示します
@@ -11,7 +16,7 @@ import { eventContainerClass } from "@/styles/event";
  * 
  * 使用例:
  */
-export default function VenueView() {
+export default function VenueView({ event }: Readonly<Props>) {
   return (
     <div className={eventContainerClass}>
       <div className="flex justify-end items-center w-full gap-x-2">
@@ -19,12 +24,18 @@ export default function VenueView() {
           name: "venueEdit",
           iconName: "Pencil",
           description: "編集",
-          href: "/event/venueedit/sample",
+          href: `/event/venueedit/${event.eventId}`,
           iconClassName: "w-6 h-6",
         }} />
       </div>
-      <div className="flex justify-center items-center mx-2 rounded-lg">
-        <img src="https://images.ygoprodeck.com/images/cards_cropped/99543666.jpg" alt="間取りの情報" width={300} height={300} />
+      <div className="flex justify-center items-center mx-2 rounded-lg h-full">
+        {event.imageUrl ? (
+          <img src={event.imageUrl} alt="間取りの情報" width={300} height={300} />
+        ) : (
+          <div className="flex justify-center items-center w-full h-full rounded-lg">
+            <p>間取りの情報がありません</p>
+          </div>
+        )}
       </div>
     </div>
   )

--- a/front/src/hooks/event/view/useEventSample.ts
+++ b/front/src/hooks/event/view/useEventSample.ts
@@ -1,0 +1,13 @@
+import { eventSample } from "@/actions/event/sample";
+import { useCallback } from "react";
+
+/**
+ * イベントサンプル生成のフック
+ * 
+ * @returns イベントサンプル生成のコールバック関数
+ */
+export function useEventSample() {
+  return useCallback(async () => {
+    await eventSample();
+  }, []);
+} 

--- a/front/src/hooks/event/view/useEventViewHeaderIconUnits.ts
+++ b/front/src/hooks/event/view/useEventViewHeaderIconUnits.ts
@@ -1,0 +1,24 @@
+import { CommonViewIconUnit } from "@/types/common/view";
+import { EventViewViewModel } from "@/types/event/viewmodel";
+import { EVENT_VIEW_HEADER_ICON_UNITS_BASE } from "@/lib/event/view/constants";
+import { useIconUnitList } from "@/lib/viewmodel/iconunit";
+
+/**
+ * イベントビューモデルからヘッダー用アイコンユニットリストを生成
+ * 
+ * @param event イベントビューモデル
+ * @returns ヘッダー用アイコンユニットリスト
+ */
+export function useEventViewHeaderIconUnits(event: EventViewViewModel): CommonViewIconUnit[] {
+  return useIconUnitList(
+    EVENT_VIEW_HEADER_ICON_UNITS_BASE,
+    {
+      eventName: { description: event.eventName },
+      eventShareLinkUrl: {
+        description: "もくもく部屋リンク",
+        href: event.eventShareLinkUrl,
+      },
+      description: { description: event.description },
+    }
+  );
+} 

--- a/front/src/hooks/event/view/useEventViewIconUnits.ts
+++ b/front/src/hooks/event/view/useEventViewIconUnits.ts
@@ -1,0 +1,29 @@
+import { CommonViewIconUnit } from "@/types/common/view";
+import { EventViewViewModel } from "@/types/event/viewmodel";
+import { EVENT_VIEW_ICON_UNITS_BASE } from "@/lib/event/view/constants";
+import { useIconUnitList } from "@/lib/viewmodel/iconunit";
+
+/**
+ * イベントビューモデルからアイコンユニットリストを生成
+ * 
+ * @param event イベントビューモデル
+ * @returns アイコンユニットリスト
+ */
+export function useEventViewIconUnits(event: EventViewViewModel): CommonViewIconUnit[] {
+  return useIconUnitList(
+    EVENT_VIEW_ICON_UNITS_BASE,
+    {
+      userGroup: { description: event.userGroupName, href: event.userGroupUrl },
+      startDateTime: { description: event.eventStartDateTime },
+      endDateTime: { description: `　　　〜　${event.eventEndDateTime}` },
+      venueLink: event.venueUrl ? { 
+        href: event.venueUrl,
+        description: "会場リンク"
+      } : {},
+      eventLink: event.eventUrl ? { 
+        href: event.eventUrl,
+        description: "イベントリンク"
+      } : {},
+    }
+  );
+} 

--- a/front/src/lib/db/user_group.ts
+++ b/front/src/lib/db/user_group.ts
@@ -55,3 +55,20 @@ export async function insertUserGroup(
 
   return inserted;
 }
+
+/**
+ * ユーザーグループIDからユーザーグループを取得
+ * 
+ * 見つからなければ、nullを返却
+ * @param id ユーザーグループID
+ * @returns ユーザーグループ
+ */
+export async function selectUserGroupById(id: number) {
+  const result = await db
+    .select()
+    .from(userGroups)
+    .where(eq(userGroups.id, id))
+    .limit(1);
+
+  return result[0] ?? null;
+}

--- a/front/src/lib/event/view/constants.ts
+++ b/front/src/lib/event/view/constants.ts
@@ -1,0 +1,59 @@
+import { CommonViewIconUnit } from "@/types/common/view";
+
+/**
+ * イベントのビューのヘッダーのアイコンユニットリストのデフォルト
+ */
+export const EVENT_VIEW_HEADER_ICON_UNITS_BASE: CommonViewIconUnit[] = [
+  {
+    name: "eventName",
+    iconName: "Megaphone",
+    description: "サンプルイベント",
+    descriptionClassName: "text-2xl font-bold",
+  },
+  {
+    name: "eventShareLinkUrl",
+    iconName: "Link2",
+    description: "もくもく部屋リンク",
+    href: "/room/sample",
+    descriptionClassName: "text-xl font-bold",
+  },
+  {
+    name: "description",
+    iconName: "FileText",
+    description: "オフラインで開催予定のイベントです",
+    descriptionClassName: "text-lg font-bold",
+  },
+]; 
+
+/**
+ * イベントのビューのアイコンユニットリストのデフォルト
+ */
+export const EVENT_VIEW_ICON_UNITS_BASE: CommonViewIconUnit[] = [
+  {
+    name: "userGroup",
+    iconName: "Users",
+    description: "ユーザーグループ",
+    descriptionClassName: "text-xl font-bold",
+  },
+  {
+    name: "startDateTime",
+    iconName: "Calendar",
+    description: "開始時間",
+    descriptionClassName: "text-lg font-bold",
+  },
+  {
+    name: "endDateTime",
+    description: "終了時間",
+    descriptionClassName: "text-lg font-bold",
+  },
+  {
+    name: "venueLink",
+    iconName: "Link",
+    descriptionClassName: "text-md font-bold",
+  },
+  {
+    name: "eventLink",
+    iconName: "Link",
+    descriptionClassName: "text-md font-bold",
+  }
+];

--- a/front/src/lib/util/date.ts
+++ b/front/src/lib/util/date.ts
@@ -1,0 +1,15 @@
+/**
+ * 日時を日本語形式にフォーマット
+ * 
+ * @param date 日時
+ * @returns フォーマットされた日時文字列（YYYY年MM月dd日 HH:mm）
+ */
+export function formatDateTimeYYYYMMDDHHMMJPN(date: Date): string {
+  const year = date.getFullYear();
+  const month = date.getMonth() + 1;
+  const day = date.getDate();
+  const hours = date.getHours().toString().padStart(2, '0');
+  const minutes = date.getMinutes().toString().padStart(2, '0');
+
+  return `${year}年${month}月${day}日 ${hours}:${minutes}`;
+} 

--- a/front/src/lib/viewmodel/iconunit.ts
+++ b/front/src/lib/viewmodel/iconunit.ts
@@ -1,0 +1,32 @@
+import { CommonViewIconUnit } from "@/types/common/view";
+import { useMemo } from "react";
+
+/**
+ * アイコンユニットの値のマッピング
+ */
+export type IconUnitValueMapping = Omit<CommonViewIconUnit, 'name'>;
+
+/**
+ * アイコンユニットのアップデートロジック
+ * 
+ * @param baseUnits ベースとなるアイコンユニットリスト（constantとして指定）
+ * @param mapping アイコンユニットの値のマッピング兼フィルタリング（ビューモデルから指定）
+ * @returns アイコンユニットリスト
+ */
+export function useIconUnitList(
+  baseUnits: CommonViewIconUnit[],
+  mapping: Record<string, IconUnitValueMapping>
+): CommonViewIconUnit[] {
+  return useMemo(() => {
+    return baseUnits
+      .map((unit) => {
+        const value = mapping[unit.name];
+        if (!value) return unit;
+
+        return {
+          ...unit,
+          ...value,
+        };
+      });
+  }, [baseUnits, mapping]);
+}

--- a/front/src/types/event/viewmodel.ts
+++ b/front/src/types/event/viewmodel.ts
@@ -1,0 +1,19 @@
+
+/**
+ * イベント詳細画面用のビューモデル
+ * 
+ * template内でデータを扱う際に使います（基本的にはStringのレコードを持つだけにとどめましょう）
+ */
+export type EventViewViewModel = {
+  eventId: number;
+  eventName: string;
+  eventShareLinkUrl: string;
+  description: string;
+  eventStartDateTime: string;
+  eventEndDateTime: string;
+  eventUrl?: string;
+  venueUrl?: string;
+  userGroupName: string;
+  userGroupUrl: string;
+  imageUrl?: string;
+};


### PR DESCRIPTION
イベント詳細画面とデータベースとの紐付けができました。
前のチケットを元に登録したイベントの情報が見えるようになっています。
イベント作成→リダイレクトで情報を確認できるはずです。

- sampleパスだけでなく/event/view/${id}からも遷移できるように
- page.tsxでデータベースへの問い合わせ処理を実施
- Templateで使うデータの型としてViewModelを定義(この画面は静的な画面に近いので、それで対応できそう)
- Templateにおいてはhookを用いてデータ変換を実現する
- レコードとマッピングからIconUnitを作成するロジックを作成
- lib/user_groupにロジックを追加
- その他、constantやutilなどを定義