### PR TITLE
【イベント】【間取り編集】保存時にGyazoAPIを使って画像を保存し、urlを生成する #129

### DIFF
--- a/front/src/actions/event/saveVenueInfo.ts
+++ b/front/src/actions/event/saveVenueInfo.ts
@@ -3,6 +3,7 @@
 import { auth } from "@/lib/auth/auth";
 import { TextState } from "@/types/event/state";
 import { generateImage } from "@/lib/event/venueedit/nodeCanvasControl";  
+import { BASE_URL } from "@/app/env";
 
 /**
  * 会場の情報を永続化するためのパラメータ
@@ -56,14 +57,33 @@ export async function saveVenueInfo({
     gridWidth
   });
   
+  // BufferをUint8Arrayに変換してからBlobを作成
+  const uint8Array = new Uint8Array(imageBuffer);
+  const blob = new Blob([uint8Array], { type: 'image/png' });
+  
+  // APIに送信する処理
+  const response = await fetch(`${BASE_URL}/api/event/gyazo`, {
+    method: 'POST',
+    body: blob
+  });
+
+  if (!response.ok) {
+    throw new Error('画像のアップロードに失敗しました');
+  }
+
+  const result = await response.json();
+
+  // TODO: レスポンスをそのまま表示、この中にURLが含まれる。次のブランチで消す。
+  console.log(result);
+  
   // TODO: 画像を保存する
   // 仮の実装として、Base64形式に変換して返す
   const base64Data = imageBuffer.toString('base64');
-  console.log(base64Data)
   const imageUrl = `data:image/png;base64,${base64Data}`;
 
   return {
     imageUrl,
-    message: '画像が生成されました'
+    message: '画像が生成されました',
+    gyazoUrl: result.data.url
   };
 } 

--- a/front/src/app/api/event/gyazo/route.ts
+++ b/front/src/app/api/event/gyazo/route.ts
@@ -1,0 +1,58 @@
+import { createGyazoHeader } from "@/lib/api/gyazo";
+
+/**
+ * 画像をGyazoにアップロードするAPIルート
+ * reqにはblobを入れればいい
+ * 使い方：
+ * ```ts
+ * const res = await fetch('${process.env.NEXT_PUBLIC_BASE_URL}/api/event/gyazo', {
+ *   method: 'POST',
+ *   body: blob
+ * });
+ * ```
+ * 
+ * 
+ * @param req リクエスト(画像データ)
+ * @returns レスポンス(Gyazo APIからのレスポンス)
+ */
+export async function POST(req: Request) {
+  try {
+    const imageBuffer = await req.arrayBuffer();
+    if (!imageBuffer) {
+      return Response.json(
+        { error: '画像データが必要です' },
+        { status: 400 }
+      );
+    }
+
+    const url = `${process.env.GYAZO_UPLOAD_END_POINT}`;
+    const headers = await createGyazoHeader();
+    
+    const formData = new FormData();
+    formData.append('imagedata', new Blob([imageBuffer], { type: 'image/png' }));
+
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: headers,
+      body: formData
+    });
+    
+    if (!res.ok) {
+      const errorData = await res.json().catch(() => ({}));
+      return Response.json(
+        { error: 'Gyazoへのアップロードに失敗しました', details: errorData },
+        { status: res.status }
+      );
+    }
+    
+    // Gyazo APIからのレスポンスをそのまま返す
+    const data = await res.json();
+    return Response.json({ data, status: res.status });
+  } catch (error) {
+    console.error('Gyazoアップロードエラー:', error);
+    return Response.json(
+      { error: 'サーバーエラーが発生しました' },
+      { status: 500 }
+    );
+  }
+}

--- a/front/src/app/api/event/gyazo/route.ts
+++ b/front/src/app/api/event/gyazo/route.ts
@@ -19,7 +19,7 @@ export async function POST(req: Request) {
   try {
     const imageBuffer = await req.arrayBuffer();
     if (!imageBuffer) {
-      return Response.json(
+      return NextResponse.json(
         { error: '画像データが必要です' },
         { status: 400 }
       );

--- a/front/src/app/env.ts
+++ b/front/src/app/env.ts
@@ -4,3 +4,5 @@ export const PROTOCOL = PARTYKIT_HOST.startsWith("127.0.0.1")
   ? "http"
   : "https";
 export const PARTYKIT_URL = `${PROTOCOL}://${PARTYKIT_HOST}`;
+
+export const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL ?? "http://localhost:3000";

--- a/front/src/hooks/event/venueedit/image/useImageAction.ts
+++ b/front/src/hooks/event/venueedit/image/useImageAction.ts
@@ -25,10 +25,6 @@ export const useImageAction = (props: Props) => {
       setIsPendingForSave(true)
       const encoded = encodeVenue(numPixel, pixelColorState, circleColorState, textState)
       await Promise.all([
-        // TODO: 本番リリース前に必ず削除
-        // デバッグ用のJSONファイルをダウンロード
-        downloadVenueJson(numPixel, pixelColorState, circleColorState, textState),  
-
         // 画像データを保存&永続化
         saveVenueInfo({
           numPixel,

--- a/front/src/lib/api/gyazo.ts
+++ b/front/src/lib/api/gyazo.ts
@@ -1,0 +1,7 @@
+'use server'
+
+export async function createGyazoHeader() {
+  return {
+    'Authorization': `Bearer ${process.env.GYAZO_ACCESS_TOKEN}`,
+  }
+}

--- a/localgyazo/check_gyazo_container_apache_log.sh
+++ b/localgyazo/check_gyazo_container_apache_log.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+# コンテナのApacheログを確認する(直近50行)
+docker exec -it gyazo-local tail -n 50 /var/log/apache2/error.log


### PR DESCRIPTION
タイトルの通り、Gyazoのエンドポイントへのアップロードができました。DBへの永続化は別チケットでの対応です。
キリがいいので、ここで切らせてもらいます。

- gyazoローカルコンテナのApacheログを確認するシェルを追加
- JSONがダウンロードされる仕組みを除外
- Next.js内で使えるroute.tsを定義
- env.tsに追加
- actions内saveVenueInfo内でAPIを呼び出せるように

また、.envファイルに以下を追記してください。
GYAZO_ACCESS_TOKEN=sampletoken
GYAZO_UPLOAD_END_POINT="http://localhost:8888/upload.cgi"
NEXT_PUBLIC_BASE_URL="http://localhost:3000"

なお、docker-composeなどで、localgyazoコンテナを立ち上げておいてください。

環境変数の整備は以下のチケットなどで対応予定です。
#139 