### PR TITLE
【イベント】【間取り編集】間取りをDBに永続化したJSONから復元できる #142

### DIFF
--- a/front/src/hooks/event/venueedit/useCanvasDraw.ts
+++ b/front/src/hooks/event/venueedit/useCanvasDraw.ts
@@ -1,13 +1,12 @@
-import { useState } from 'react'
+
 import { VenueEditTool } from '@/types/tool'
 import { Color } from 'react-color'
 import { useZoom } from '@/hooks/event/venueedit/useZoom'
-import { DEFAULT_NUM_PIXEL } from '@/lib/event/venueedit/constants'
 import { useToolSelect } from '@/hooks/event/venueedit/tool/useToolSelect'
-import { TextState } from '@/types/event/state'
 import { useDrawingState } from '@/hooks/event/venueedit/useDrawingState'
 import { useImageAction } from './image/useImageAction'
 import { EventVenueEditViewModel } from '@/types/event/viewmodel'
+import { useInitialState } from '@/hooks/event/venueedit/usenInitialState'
 
 /**
  * キャンバスの描画を管理するフックのProps
@@ -33,18 +32,21 @@ export const useCanvasDraw = ({
   selectedColorBackGround,
   eventVenueEditViewModel
 }: Props) => {
-  // ピクセルの定義
-  const [numPixel, setNumPixel] = useState(DEFAULT_NUM_PIXEL)
-  const {zoom, handleZoomIn, handleZoomOut} = useZoom()
 
-  const [pixelColorState, setPixelColorState] = useState<(Color | null)[][]>(
-    Array(numPixel).fill(null).map(() => Array(numPixel).fill(null))
-  )
-  const [circleColorState, setCircleColorState] = useState<(Color | null)[][]>(
-    Array(numPixel).fill(null).map(() => Array(numPixel).fill(null))
-  )
-  const [textState, setTextState] = useState<TextState[]>([])
-  const [isDialogModalOpen, setIsDialogModalOpen] = useState(false)
+  const {
+    numPixel,
+    setNumPixel,
+    pixelColorState,
+    setPixelColorState,
+    circleColorState,
+    setCircleColorState,
+    textState,
+    setTextState,
+    isDialogModalOpen,
+    setIsDialogModalOpen
+  } = useInitialState({eventVenueEditViewModel})
+
+  const {zoom, handleZoomIn, handleZoomOut} = useZoom()
 
   const { canvasRef, startDrawing, endDrawing } = useDrawingState({
     numPixel,

--- a/front/src/hooks/event/venueedit/useDrawingState.ts
+++ b/front/src/hooks/event/venueedit/useDrawingState.ts
@@ -3,6 +3,7 @@ import { Color } from 'react-color'
 import { TextState } from '@/types/event/state'
 import { syncAllStateToCanvas, initializeCanvas } from '@/lib/event/venueedit/canvasControl'
 import { CANVAS_BASE } from '@/lib/event/venueedit/constants'
+import { resizeTwoDimensionalArray } from '@/lib/event/venueedit/arrayControl'
 
 interface Props {
   numPixel: number
@@ -43,15 +44,20 @@ export const useDrawingState = ({ numPixel, pixelColorState, circleColorState, t
     isDrawingRef.current = false
   }, [])
 
-  // 初期化・リサイズ時の処理
+  // リサイズ時の処理
   useEffect(() => {
     const canvas = canvasRef.current
     if (!canvas) return
     const ctx = initializeCanvas(canvas, numPixel)
     if (!ctx) return
-    setPixelColorState(Array(numPixel).fill(null).map(() => Array(numPixel).fill(null)))
-    setCircleColorState(Array(numPixel).fill(null).map(() => Array(numPixel).fill(null)))
-    setTextState([])
+
+    // 初期化時には後述の初期化処理を実行しない
+    setPixelColorState(prev => resizeTwoDimensionalArray(prev, numPixel))
+    setCircleColorState(prev => resizeTwoDimensionalArray(prev, numPixel))
+    setTextState(prev => prev.filter(text => 
+      text.startX < numPixel && text.startY < numPixel &&
+      text.endX < numPixel && text.endY < numPixel
+    ))
     syncAllState(ctx)
   }, [numPixel])
 

--- a/front/src/hooks/event/venueedit/usenInitialState.ts
+++ b/front/src/hooks/event/venueedit/usenInitialState.ts
@@ -1,0 +1,49 @@
+import { useState } from 'react'
+import { Color } from 'react-color'
+import { TextState } from '@/types/event/state'
+import { EventVenueEditViewModel } from '@/types/event/viewmodel'
+import { decodeVenue } from '@/lib/event/venueedit/decode'
+
+/**
+ * Propsとしてビューモデルを受け取る
+ */
+interface Props {
+  eventVenueEditViewModel: EventVenueEditViewModel
+}
+
+/**
+ * 会場編集画面の初期状態を管理するフック
+ * ビューモデル(DBに登録されていた値)から初期Stateを生成する
+ * @param eventVenueEditViewModel 会場編集画面のビューモデル
+ * 
+ * @returns 会場編集画面の状態とその更新関数
+ */
+export const useInitialState = ({eventVenueEditViewModel}: Props) => {
+
+  const {imageJson} = eventVenueEditViewModel
+  
+  const {numPixel:initialNumPixel, 
+    pixelColorState:initialPixelColorState, 
+    circleColorState:initialCircleColorState, 
+    textState:initialTextState} = decodeVenue(imageJson ?? JSON.parse('{}'))
+  
+  // ピクセルの定義
+  const [numPixel, setNumPixel] = useState(initialNumPixel)
+  const [pixelColorState, setPixelColorState] = useState<(Color | null)[][]>(initialPixelColorState)
+  const [circleColorState, setCircleColorState] = useState<(Color | null)[][]>(initialCircleColorState)
+  const [textState, setTextState] = useState<TextState[]>(initialTextState)
+  const [isDialogModalOpen, setIsDialogModalOpen] = useState(false)
+
+  return {
+    numPixel,
+    setNumPixel,
+    pixelColorState,
+    setPixelColorState,
+    circleColorState,
+    setCircleColorState,
+    textState,
+    setTextState,
+    isDialogModalOpen,
+    setIsDialogModalOpen,
+  }
+}

--- a/front/src/lib/event/venueedit/arrayControl.ts
+++ b/front/src/lib/event/venueedit/arrayControl.ts
@@ -1,0 +1,20 @@
+
+/**
+ * ２次元配列のサイズを変更する
+ * @param prev 変更前の配列
+ * @param numPixel 変更後のピクセル数
+ * @returns 変更後の配列
+ */
+export const resizeTwoDimensionalArray = <T>(prev: T[][], numPixel: number): T[][] => {
+  const newArray = Array(numPixel).fill(null).map(() => Array(numPixel).fill(null))
+  prev.forEach((row, y) => {
+    if (y < numPixel) {
+      row.forEach((color, x) => {
+        if (x < numPixel) {
+          newArray[y][x] = color
+        }
+      })
+    }
+  })
+  return newArray
+}

--- a/front/src/lib/event/venueedit/canvasControl.ts
+++ b/front/src/lib/event/venueedit/canvasControl.ts
@@ -347,7 +347,6 @@ export const drawText = (
   const startY = text.startY
   const endX = text.endX
   const endY = text.endY
-  const backgroundColor = text.backgroundColor
   const textColor = text.textColor
   const textLength = text.text.length
 

--- a/front/src/lib/event/venueedit/decode.ts
+++ b/front/src/lib/event/venueedit/decode.ts
@@ -1,5 +1,6 @@
 import { Color } from "react-color"
-import { TextState } from "@/types/event/state"
+import { EncodedVenue, TextState } from "@/types/event/state"
+import { DEFAULT_NUM_PIXEL } from "@/lib/event/venueedit/constants"
 
 /**
  * 復元された会場の情報
@@ -16,32 +17,46 @@ interface DecodedVenue {
  * @param json 会場の情報
  * @returns 復元された会場の情報
  */
-export function decodeVenue(json: string): DecodedVenue {
-  const data = JSON.parse(json)
+export function decodeVenue(json: JSON): DecodedVenue {
+  const data = json as unknown as EncodedVenue
+
+  if (!data) {
+    return {
+      numPixel: DEFAULT_NUM_PIXEL,
+      pixelColorState: Array(DEFAULT_NUM_PIXEL).fill(null).map(() => Array(DEFAULT_NUM_PIXEL).fill(null)),
+      circleColorState: Array(DEFAULT_NUM_PIXEL).fill(null).map(() => Array(DEFAULT_NUM_PIXEL).fill(null)),
+      textState: []
+    }
+  }
+
   const { numPixel, encodedPixelColor, encodedCircleColor, textState } = data
 
   // 空の二次元配列を作成
-  const pixelColorState: (Color | null)[][] = Array(numPixel).fill(null).map(() => Array(numPixel).fill(null))
-  const circleColorState: (Color | null)[][] = Array(numPixel).fill(null).map(() => Array(numPixel).fill(null))
-
-  // ピクセルカラーを復元
-  Object.entries(encodedPixelColor).forEach(([color, positions]) => {
-    (positions as {x: number, y: number}[]).forEach(({x, y}) => {
-      pixelColorState[y][x] = color as Color
+  const numPixelNew = numPixel ?? DEFAULT_NUM_PIXEL
+  const pixelColorState: (Color | null)[][] = Array(numPixelNew).fill(null).map(() => Array(numPixelNew).fill(null))
+  const circleColorState: (Color | null)[][] = Array(numPixelNew).fill(null).map(() => Array(numPixelNew).fill(null))
+  const textStateNew: TextState[] = textState ?? []
+  if(encodedPixelColor) {
+    // ピクセルカラーを復元
+    Object.entries(encodedPixelColor).forEach(([color, positions]) => {
+      (positions as {x: number, y: number}[]).forEach(({x, y}) => {
+        pixelColorState[y][x] = color as Color
+      })
     })
-  })
-
-  // 円のカラーを復元
-  Object.entries(encodedCircleColor).forEach(([color, positions]) => {
-    (positions as {x: number, y: number}[]).forEach(({x, y}) => {
-      circleColorState[y][x] = color as Color
+  }
+  if(encodedCircleColor) {
+    // 円のカラーを復元
+    Object.entries(encodedCircleColor).forEach(([color, positions]) => {
+      (positions as {x: number, y: number}[]).forEach(({x, y}) => {
+        circleColorState[y][x] = color as Color
+      })
     })
-  })
+  }
 
   return {
-    numPixel,
+    numPixel: numPixelNew,
     pixelColorState,
     circleColorState,
-    textState
+    textState: textStateNew
   }
 } 

--- a/front/src/lib/event/venueedit/decode.ts
+++ b/front/src/lib/event/venueedit/decode.ts
@@ -17,8 +17,8 @@ interface DecodedVenue {
  * @param json 会場の情報
  * @returns 復元された会場の情報
  */
-export function decodeVenue(json: JSON): DecodedVenue {
-  const data = json as unknown as EncodedVenue
+export function decodeVenue(json: string | EncodedVenue): DecodedVenue {
+  const data: EncodedVenue = typeof json === "string" ? JSON.parse(json) : json;
 
   if (!data) {
     return {


### PR DESCRIPTION
イベント詳細から間取り編集を開いた際に、DBに保存済みの間取り情報から描画が再開できるようになりました。

具体的には、データベースからProps経由で渡したJSONから、描画を再開できるようになりました.
その過程で、ピクセル数を変化させた時の挙動を若干変えています（状態を保持しつつピクセル数を変更できるようにしました）。

- ビューモデルから初期Stateを作成するよう挙動を変更
- ピクセル数変更時の挙動を修正
- 初期Stateの定義を専用のフックに移管
- 2次元配列に関する操作をlibに定義
- JSON→Stateの変換の際に、不完全なデータからでも復元できるようにしました