### PR TITLE
【イベント】【イベント編集】イベント編集機能を新規登録と同じUIで更新できるようにする #127

### DIFF
--- a/front/src/actions/event/eventedit/updateEventInfo.ts
+++ b/front/src/actions/event/eventedit/updateEventInfo.ts
@@ -1,0 +1,153 @@
+'use server';
+
+import { z } from 'zod'
+import { FormState } from '@/types/common/form';
+import { DATE_PATTERN, TIME_PATTERN } from '@/lib/util/constants';
+import { selectEventById, updateEvent } from '@/lib/db/event';
+import { db } from '@/lib/db';
+import { revalidatePath } from 'next/cache';
+import { redirect } from 'next/navigation';
+import { Event, UpdateEvent } from "@/types/event/schema";
+
+/**
+ * 単一バリデーション
+ */
+const BaseSchema = z.object({
+  name: z.string({
+    required_error: 'イベント名は必須です。',
+  }),
+  description: z.string({
+    required_error: 'イベントの説明は必須です。',
+  }),
+  userGroupId: z.coerce.number({
+    required_error: 'ユーザーグループは必須です。',
+  }),
+  eventDate: z.string()
+    .regex(DATE_PATTERN, 'イベント日はYYYY-MM-DD形式で入力してください。')
+    .refine((date) => !isNaN(Date.parse(date)), '有効な日付を入力してください。'),
+  eventStartTime: z.string()
+    .regex(TIME_PATTERN, '開始時刻はHH:mm形式で入力してください。'),
+  eventEndTime: z.string()
+    .regex(TIME_PATTERN, '終了時刻はHH:mm形式で入力してください。'),
+  eventUrl: z.string().url('イベントの詳細URLが有効な形式ではありません。').optional().or(z.literal('')),
+  venueUrl: z.string().url('会場のURLが有効な形式ではありません。').optional().or(z.literal(''))
+}).refine(
+  (data) => {
+    const startTime = new Date(`${data.eventDate}T${data.eventStartTime}`);
+    const endTime = new Date(`${data.eventDate}T${data.eventEndTime}`);
+    return startTime < endTime;
+  },
+  {
+    message: '終了時刻は開始時刻より後である必要があります。',
+    path: ['eventEndTime']
+  }
+);
+
+/**
+ * 相関バリデーション（開始時刻と終了時刻の比較）
+ */
+const FormSchema = BaseSchema.refine(
+  (data) => {
+    const startTime = new Date(`${data.eventDate}T${data.eventStartTime}`);
+    const endTime = new Date(`${data.eventDate}T${data.eventEndTime}`);
+    return startTime < endTime;
+  },
+  {
+    message: '終了時刻は開始時刻より後である必要があります。',
+    path: ['eventEndTime']
+  }
+);
+
+
+const createUpdateEventEntity = (oldEvent: Event, validatedFields: any): UpdateEvent => {
+  const { eventDate, eventStartTime, eventEndTime, ...rest } = validatedFields.data;
+  const {id: _, ...restWithoutId} = oldEvent;
+
+  return {
+    ...restWithoutId,
+    ...rest,
+    startDateTime: new Date(`${eventDate}T${eventStartTime}:00.000`),
+    endDateTime: new Date(`${eventDate}T${eventEndTime}:00.000`),
+  };
+};
+
+/**
+ * イベントを登録
+ * 
+ * @param prevState 前回の状態
+ * @param formData フォームデータ
+ * @returns 処理結果（エラーがあれば、エラーとフォームデータが返却される）
+ */
+export async function updateEventInfo(
+  prevState: FormState,
+  formData: FormData,
+  eventId: number
+): Promise<FormState> {
+
+  // まず基本バリデーションを実行
+  const baseValidation = BaseSchema.safeParse({
+    name: formData.get('name'),
+    description: formData.get('description'),
+    userGroupId: formData.get('userGroupId'),
+    eventDate: formData.get('eventDate'),
+    eventStartTime: formData.get('eventStartTime'),
+    eventEndTime: formData.get('eventEndTime'),
+    eventUrl: formData.get('eventUrl'),
+    venueUrl: formData.get('venueUrl')
+  });
+
+  // 基本バリデーションでエラーがあれば、そのエラーを返却
+  if (!baseValidation.success) {
+    return {
+      error: baseValidation.error.errors,
+      formData: Object.fromEntries(formData.entries())
+    };
+  }
+
+  // 基本バリデーションが成功した場合のみ、時刻の比較バリデーションを実行
+  const validatedFields = FormSchema.safeParse(baseValidation.data);
+
+  // バリデーションエラーがあれば、エラーとフォームデータを返却
+  if (!validatedFields.success) {
+    return {
+      error: validatedFields.error.errors,
+      formData: Object.fromEntries(formData.entries())
+    };
+  }
+
+  const oldEvent = await selectEventById(eventId);
+
+  if (!oldEvent) {
+    return {
+      error: [{ 
+        message: 'イベントが見つかりませんでした。もう一度試してください',
+        code: 'custom',
+        path: []
+      }],
+      formData: Object.fromEntries(formData.entries())
+    };
+  }
+
+  // DBにすでにあるデータとフォームデータを結合して、新しいイベントエンティティを作成
+  const newEvent = createUpdateEventEntity(oldEvent, validatedFields);
+
+  // イベントの登録処理(トランザクションは正直なくてもいいけど、lib/db側の記述がシンプルになるために使用)
+  const updatedEvent = await db.transaction(async (tx) => {
+    return await updateEvent(tx, eventId, newEvent);
+  });
+
+  // イベントの更新に失敗した場合はエラーを返却
+  if (!updatedEvent) {
+    return {
+      error: [{ 
+        message: 'イベントの更新に失敗しました。もう一度試してください',
+        code: 'custom',
+        path: []
+      }],
+      formData: Object.fromEntries(formData.entries())
+    };
+  }
+
+  revalidatePath(`/event/edit/${updatedEvent.id}`);
+  redirect(`/event/view/${updatedEvent.id}`);
+}

--- a/front/src/actions/event/eventedit/viewmodel.ts
+++ b/front/src/actions/event/eventedit/viewmodel.ts
@@ -1,0 +1,40 @@
+import { selectEventById } from "@/lib/db/event";
+import { selectUserGroupById } from "@/lib/db/user_group";
+import { formatDateTimeHHMM, formatDateTimeYYYYMMDD_HYPHEN, formatDateTimeYYYYMMDD_SLASH } from "@/lib/util/date";
+import { EventEditViewModel } from "@/types/event/viewmodel";
+
+/**
+ * イベントIDからイベント詳細ビューモデルを取得
+ * 
+ * @param eventId イベントID
+ * @returns イベント詳細のビューモデル
+ */
+export async function getEventEditViewModel(eventId: number): Promise<EventEditViewModel | null> {
+  // イベントを取得
+  const event = await selectEventById(eventId);
+  
+  // イベントが見つからない場合はエラーを返す
+  if (!event) {
+    return null;
+  }
+
+  // ユーザーグループを取得
+  const userGroup = await selectUserGroupById(event.userGroupId);
+  if (!userGroup) {
+    return null;
+  }
+
+  // イベント詳細ビューモデルを作成
+  return {
+    eventId: event.id,
+    eventName: event.name,
+    description: event.description ?? '',
+    userGroupId: event.userGroupId, 
+    userGroupName: userGroup.name,
+    eventDate: formatDateTimeYYYYMMDD_HYPHEN(event.startDateTime),
+    eventStartTime: formatDateTimeHHMM(event.startDateTime),
+    eventEndTime: formatDateTimeHHMM(event.endDateTime),
+    eventUrl: event.eventUrl ?? undefined,
+    venueUrl: event.venueUrl ?? undefined,
+  };
+}

--- a/front/src/app/(withsidebar)/event/eventedit/[eventId]/page.tsx
+++ b/front/src/app/(withsidebar)/event/eventedit/[eventId]/page.tsx
@@ -1,7 +1,29 @@
-export default function EventEditPage() {
-  return (
-    <div>
-      EventEdit
-    </div>
-  )
+import EventEditTemplate from "@/components/templates/event/eventedit/EventEditTemplate";
+import { getEventEditViewModel } from "@/actions/event/eventedit/viewmodel";
+import { notFound } from "next/navigation";
+
+export default async function EventViewPage({
+  params,
+}: {
+  params: Promise<{ eventId: string }>;
+}) {
+  const { eventId } = await params;
+  
+  // 数字にパース
+  const eventIdNumber = Number(eventId);
+  
+  // idが数字でない場合はエラーを返す
+  if (Number.isNaN(eventIdNumber)) {
+    return notFound();
+  }
+
+  // イベント詳細画面用のビューモデルを取得
+  const eventViewModel = await getEventEditViewModel(eventIdNumber);
+  
+  if (!eventViewModel) {
+    return notFound();
+  }
+
+  // イベント編集画面を表示
+  return <EventEditTemplate eventViewModel={eventViewModel} />;
 } 

--- a/front/src/components/templates/event/eventedit/EventEditTemplate.tsx
+++ b/front/src/components/templates/event/eventedit/EventEditTemplate.tsx
@@ -1,0 +1,101 @@
+'use client';
+
+import CommonRegisterTemplate from '@/components/templates/common/CommonRegisterTemplate';
+import { useState } from 'react';
+import type { EventRegisterFormField, EventRegisterForm } from '@/types/event/form';
+import { FormState } from '@/types/common/form';
+import { EventEditViewModel } from '@/types/event/viewmodel';
+import { EVENT_EDIT_FORM_FIELDS } from '@/lib/event/eventedit/constants';
+import { updateEventInfo } from '@/actions/event/eventedit/updateEventInfo';
+
+interface EventEditTemplateProps {
+  eventViewModel: EventEditViewModel;
+}
+
+/**
+ * イベント編集テンプレート
+ * 
+ * @param event イベント情報ビューモデル
+ * @returns イベント編集テンプレート
+ */
+export default function EventEditTemplate({ eventViewModel }: Readonly<EventEditTemplateProps>) {
+  const { eventId,
+          eventName,
+          description, 
+          eventDate, 
+          eventStartTime, 
+          eventEndTime, 
+          eventUrl, 
+          venueUrl, 
+          userGroupName, 
+          userGroupId } = eventViewModel;
+  
+  // オプションの値を代入する
+  const [formFields] = useState<EventRegisterFormField[]>(
+    EVENT_EDIT_FORM_FIELDS.map((field) => {
+      switch (field?.name) {
+        case 'userGroupId':
+          return {
+            ...field,
+            defaultValue: userGroupId.toString(),
+            options: [{
+              value: userGroupId.toString(),
+              label: userGroupName  
+            }]
+          }
+        case 'name':
+          return {
+            ...field,
+            defaultValue: eventName
+          }
+        case 'description':
+          return {
+            ...field,
+            defaultValue: description
+          }
+        case 'eventDate':
+          return {
+            ...field,
+            defaultValue: eventDate
+          }
+        case 'eventStartTime':
+          return {
+            ...field,
+            defaultValue: eventStartTime
+          }
+        case 'eventEndTime':
+          return {
+            ...field,
+            defaultValue: eventEndTime
+          }
+        case 'eventUrl':
+          return {
+            ...field,
+            defaultValue: eventUrl
+          }
+        case 'venueUrl':  
+          return {
+            ...field,
+            defaultValue: venueUrl
+          }
+        default:
+          return field
+      }
+    })
+  );
+
+  // サブミット時に送信する関数を定義します
+  // ラップしているだけに見えるかもしれませんが、
+  // IDなどinput要素として入れておきたくないものを事前に渡せるようにしています。
+  const onSubmit = (state: FormState, formData: FormData) => {
+    return updateEventInfo(state, formData, eventId);
+  }
+
+  return (
+    <CommonRegisterTemplate<EventRegisterForm>
+      title="イベント編集"
+      fields={formFields}
+      onSubmit={onSubmit}
+    />
+  );
+}

--- a/front/src/lib/event/eventedit/constants.ts
+++ b/front/src/lib/event/eventedit/constants.ts
@@ -1,0 +1,130 @@
+import { EventRegisterFormField } from '@/types/event/form'
+
+/**
+ * イベント編集フォームのフィールド定義
+ * 
+ * ```ts
+ *   {
+ *   name: 'name',
+ *   label: 'イベント名',
+ *   required: true,
+ *   elementType: 'input',
+ *   inputType: 'text',
+ *   placeholder: 'イベント名を入力してください'
+ * },
+ * {
+ *   name: 'description',
+ *   label: 'イベントの概要',
+ *   required: true,
+ *   elementType: 'textarea',
+ *   placeholder: 'イベントの概要を入力してください'
+ * },
+ * {
+ *   name: 'userGroupId',
+ *   label: 'イベントグループ',
+ *   required: true,
+ *   elementType: 'select',
+ *   placeholder: 'イベントグループを選択してください'
+ * },
+ * {
+ *   name: 'eventDate',
+ *   label: 'イベント日',
+ *   required: true,
+ *   elementType: 'input',
+ *   inputType: 'date'
+ * },
+ * {
+ *   name: 'eventStartTime',
+ *   label: '開始時刻',
+ *   required: true,
+ *   elementType: 'input',
+ *   inputType: 'time'
+ * },
+ * {
+ *   name: 'eventEndTime',
+ *   label: '終了時刻',
+ *   required: true,
+ *   elementType: 'input',
+ *   inputType: 'time'
+ * },
+ * {
+ *   name: 'eventUrl',
+ *   label: 'イベントの詳細URL',
+ *   required: false,
+ *   elementType: 'input',
+ *   inputType: 'text',
+ *   placeholder: 'https://example.com'
+ * },
+ * {
+ *   name: 'venueUrl',
+ *   label: '会場のURL',
+ *   required: false,
+ *   elementType: 'input',
+ *   inputType: 'text',
+ *   placeholder: 'https://example.com'
+ *}
+ * ```
+ * 
+ * @returns イベント登録フォームのフィールド定義
+ */
+export const EVENT_EDIT_FORM_FIELDS: EventRegisterFormField[] = [
+  {
+    name: 'name',
+    label: 'イベント名',
+    required: true,
+    elementType: 'input',
+    inputType: 'text',
+    placeholder: 'イベント名を入力してください'
+  },
+  {
+    name: 'description',
+    label: 'イベントの概要',
+    required: true,
+    elementType: 'textarea',
+    placeholder: 'イベントの概要を入力してください'
+  },
+  {
+    name: 'userGroupId',
+    label: 'イベントグループ',
+    required: true,
+    elementType: 'select',
+    placeholder: 'イベントグループを選択してください'
+  },
+  {
+    name: 'eventDate',
+    label: 'イベント日',
+    required: true,
+    elementType: 'input',
+    inputType: 'date'
+  },
+  {
+    name: 'eventStartTime',
+    label: '開始時刻',
+    required: true,
+    elementType: 'input',
+    inputType: 'time'
+  },
+  {
+    name: 'eventEndTime',
+    label: '終了時刻',
+    required: true,
+    elementType: 'input',
+    inputType: 'time'
+  },
+  {
+    name: 'eventUrl',
+    label: 'イベントの詳細URL',
+    required: false,
+    elementType: 'input',
+    inputType: 'text',
+    placeholder: 'https://example.com'
+  },
+  {
+    name: 'venueUrl',
+    label: '会場のURL',
+    required: false,
+    elementType: 'input',
+    inputType: 'text',
+    placeholder: 'https://example.com'
+  }
+];

--- a/front/src/lib/util/date.ts
+++ b/front/src/lib/util/date.ts
@@ -1,5 +1,5 @@
 /**
- * 日時を日本語形式にフォーマット
+ * 日時を日本語形式（YYYY年MM月dd日 HH:mm）にフォーマット
  * 
  * @param date 日時
  * @returns フォーマットされた日時文字列（YYYY年MM月dd日 HH:mm）
@@ -13,3 +13,43 @@ export function formatDateTimeYYYYMMDDHHMMJPN(date: Date): string {
 
   return `${year}年${month}月${day}日 ${hours}:${minutes}`;
 } 
+/**
+ * 日時を日本語形式（YYYY/MM/dd）にフォーマット
+ * 
+ * @param date 日時
+ * @returns フォーマットされた日時文字列（YYYY/MM/dd）
+ */
+export function formatDateTimeYYYYMMDD_SLASH(date: Date): string {
+  const year = date.getFullYear().toString();
+  const month = (date.getMonth() + 1).toString().padStart(2, '0');
+  const day = date.getDate().toString().padStart(2, '0');
+
+  return `${year}/${month}/${day}`;
+}
+
+/**
+ * 日時を日本語形式（YYYY-MM-dd）にフォーマット
+ * 
+ * @param date 日時
+ * @returns フォーマットされた日時文字列（YYYY-MM-dd）
+ */
+export function formatDateTimeYYYYMMDD_HYPHEN(date: Date): string {
+  const year = date.getFullYear().toString();
+  const month = (date.getMonth() + 1).toString().padStart(2, '0');
+  const day = date.getDate().toString().padStart(2, '0');
+
+  return `${year}-${month}-${day}`;
+}
+
+/**
+ * 日時を日本語形式（HH:mm）にフォーマット
+ * 
+ * @param date 日時
+ * @returns フォーマットされた日時文字列（YYYY年MM月dd日 HH:mm）
+ */
+export function formatDateTimeHHMM(date: Date): string {
+  const hours = date.getHours().toString().padStart(2, '0');
+  const minutes = date.getMinutes().toString().padStart(2, '0');
+
+  return `${hours}:${minutes}`;
+}

--- a/front/src/types/event/viewmodel.ts
+++ b/front/src/types/event/viewmodel.ts
@@ -27,3 +27,21 @@ export type EventVenueEditViewModel = {
   eventName: string;
   imageJson?: JSON;
 };
+
+/**
+ * イベント編集画面用のビューモデル
+ * 
+ * template内でデータを扱う際に使います（基本的にはStringのレコードを持つだけにとどめましょう）
+ */
+export type EventEditViewModel = {
+  eventId: number;
+  eventName: string;
+  userGroupId: number;
+  userGroupName: string;
+  description: string;
+  eventDate: string;
+  eventStartTime: string;
+  eventEndTime: string;
+  eventUrl?: string;
+  venueUrl?: string;
+};


### PR DESCRIPTION
イベント情報の編集ができるようになりました（間取り編集とは別です）。

- イベント編集用のパスを準備して、詳細から飛べるように
- イベント編集のためのviewmodelを定義
- イベント編集のためのviewmodelの型を定義
- イベント編集のためのフォームフィールドを定義
- EventEditTemplateを準備(とはEventRegisterTemplateと本質は同じ)
- 日付時刻変換Utilに関数を追加