### PR TITLE
【共通】【shadcn】サイドメニューのクラス設定により、要素の高さが小さい場合でも余計にスクロールできてしまう #163

### DIFF
--- a/front/src/components/atoms/shadcn/sidebar.tsx
+++ b/front/src/components/atoms/shadcn/sidebar.tsx
@@ -139,7 +139,7 @@ function SidebarProvider({
             } as React.CSSProperties
           }
           className={cn(
-            "group/sidebar-wrapper has-data-[variant=inset]:bg-sidebar flex min-h-svh w-full",
+            "group/sidebar-wrapper has-data-[variant=inset]:bg-sidebar flex w-full",
             className
           )}
           {...props}


### PR DESCRIPTION
shadcnのサイドバーコンポーネントにおいて、 min-h-svhをメイン要素に入れる設定があります。 これにより、要素の高さが十分に小さいにも関わらず、
下に空白が作られた上で、さらに不必要にスクロールできてしまう現象が確認できました。

<img width="1438" alt="Image" src="https://github.com/user-attachments/assets/b7abc501-0400-48b0-83da-dd794159f67c" />

不自然にスクロールできてしまうのには違和感があるので、修正を行いたいです。

次のように、sidebar.tsx内のクラス設定をいじることで解決できることを確認しております。
```diff

  return (
    <SidebarContext.Provider value={contextValue}>
      <TooltipProvider delayDuration={0}>
        <div
          data-slot="sidebar-wrapper"
          style={
            {
              "--sidebar-width": SIDEBAR_WIDTH,
              "--sidebar-width-icon": SIDEBAR_WIDTH_ICON,
              ...style,
            } as React.CSSProperties
          }
          className={cn(
-            "group/sidebar-wrapper has-data-[variant=inset]:bg-sidebar flex min-h-svh w-full",
+             "group/sidebar-wrapper has-data-[variant=inset]:bg-sidebar flex w-full",
            className
          )}
          {...props}
        >
          {children}
        </div>
      </TooltipProvider>
    </SidebarContext.Provider>
  )
```

変更後：
余計なスクロールバーが消えました。
<img width="1388" alt="Image" src="https://github.com/user-attachments/assets/9dae7243-17a0-427a-87a5-2685a685ffdc" />

以下のような状況ですので、修正を行いたいです
サイドバーなし→本修正の影響を受けない
サイドバーあり&メインの要素の高さが大きいもの→影響なし
サイドバーあり&メインの要素の高さが小さいもの→今回の修正で改善