### PR TITLE
【イベント】【間取り編集】余分なツールの削除 #192

### DIFF
--- a/front/src/components/organisms/event/venueedit/palette/ColorPalette.tsx
+++ b/front/src/components/organisms/event/venueedit/palette/ColorPalette.tsx
@@ -20,7 +20,7 @@ export default function ColorPalette({
   onDeleteColor
 }: Readonly<ColorPaletteProps>) {
   return (
-    <div className="grid grid-cols-12 lg:grid-cols-4 gap-2">
+    <div className="grid grid-cols-12 lg:grid-cols-4 xl:grid-cols-8 gap-2">
       {colors.map((color) => (
         <ColorButton
           key={color.toString()}

--- a/front/src/components/organisms/event/venueedit/tools/ToolButtonGroup.tsx
+++ b/front/src/components/organisms/event/venueedit/tools/ToolButtonGroup.tsx
@@ -5,63 +5,24 @@ interface ToolButtonGroupProps {
   onToolSelect: (tool: VenueEditTool) => void
 }
 
+/**
+ * ツールボタングループ
+ * 
+ * @param onToolSelect ツール選択時のコールバック
+ * @returns ツールボタングループ
+ */
 export default function ToolButtonGroup({ onToolSelect }: Readonly<ToolButtonGroupProps>) {
   return (
     <div className="grid grid-cols-6 xl:grid-cols-1 gap-2">
-      <div className="col-span-1 grid grid-cols-1 xl:grid-cols-2 grid-rows-2 xl:grid-rows-1 gap-2">
-        {VENUE_EDIT_TOOLS.slice(0, 2).map((tool) => (
-          <MonoClomeButton 
-            key={tool}
-            onClick={() => onToolSelect(tool)}
+      {VENUE_EDIT_TOOLS.map((tool) => (
+        <MonoClomeButton 
+          key={tool}
+          onClick={() => onToolSelect(tool)}
+          className="col-span-1 grid grid-cols-1 gap-2"
           >
-            {tool}
-          </MonoClomeButton>
-        ))}
-      </div>
-
-      <div className="col-span-1 grid grid-cols-1 xl:grid-cols-2 grid-rows-2 xl:grid-rows-1 gap-2">
-        {VENUE_EDIT_TOOLS.slice(2, 4).map((tool) => (
-          <MonoClomeButton 
-            key={tool}
-            onClick={() => onToolSelect(tool)}
-          >
-            {tool}
-          </MonoClomeButton>
-        ))}
-      </div>
-
-      <div className="col-span-1 grid grid-cols-1 xl:grid-cols-2 grid-rows-2 xl:grid-rows-1 gap-2">
-        {VENUE_EDIT_TOOLS.slice(4, 6).map((tool) => (
-          <MonoClomeButton 
-            key={tool}
-            onClick={() => onToolSelect(tool)}
-          >
-            {tool}
-          </MonoClomeButton>
-        ))}
-      </div>
-
-      <div className="col-span-1 grid grid-cols-1 xl:grid-cols-2 grid-rows-2 xl:grid-rows-1 gap-2">
-        {VENUE_EDIT_TOOLS.slice(6, 8).map((tool) => (
-          <MonoClomeButton 
-            key={tool}
-            onClick={() => onToolSelect(tool)}
-          >
-            {tool}
-          </MonoClomeButton>
-        ))}
-      </div>
-
-      <div className="col-span-1 grid grid-cols-1 xl:grid-cols-2 grid-rows-2 xl:grid-rows-1 gap-2">
-        {VENUE_EDIT_TOOLS.slice(8, 10).map((tool) => (
-          <MonoClomeButton 
-            key={tool}
-            onClick={() => onToolSelect(tool)}
-          >
-            {tool}
-          </MonoClomeButton>
-        ))}
-      </div>
+          {tool}
+        </MonoClomeButton>
+      ))}
     </div>
   )
-} 
+}

--- a/front/src/components/templates/event/venueedit/VenueEditorTemplate.tsx
+++ b/front/src/components/templates/event/venueedit/VenueEditorTemplate.tsx
@@ -15,6 +15,11 @@ interface Props {
   eventVenueEditViewModel: EventVenueEditViewModel
 }
 
+/**
+ * 会場編集画面のテンプレート
+ * 
+ * @param eventVenueEditViewModel 会場編集ビューモデル
+ */
 export default function VenueEditorTemplate({ eventVenueEditViewModel }: Readonly<Props>) {
   const [selectedTool, setSelectedTool] = useState<VenueEditTool>('ピクセル塗りつぶし')
   const { 
@@ -75,7 +80,7 @@ export default function VenueEditorTemplate({ eventVenueEditViewModel }: Readonl
               handleMouseLeave={handleMouseLeave}
             />
           </div>
-          <div className="col-span-1 md:col-span-1 lg:col-span-2 xl:col-span-2">
+          <div className="col-span-1 md:col-span-1 lg:col-span-2 xl:col-span-4">
             <VenueToolSubMenu 
               selectedTool={selectedTool}
               onToolSelect={setSelectedTool}
@@ -94,7 +99,7 @@ export default function VenueEditorTemplate({ eventVenueEditViewModel }: Readonl
               onAdd={handleTextAdd}
             />
           </div>
-          <div className="col-span-1 md:col-span-1 lg:col-span-8 xl:col-span-4">
+          <div className="col-span-1 md:col-span-1 lg:col-span-8 xl:col-span-2">
             <VenueToolSelectionMenu 
               onToolSelect={setSelectedTool}
             />

--- a/front/src/types/tool.ts
+++ b/front/src/types/tool.ts
@@ -6,12 +6,8 @@ export const VENUE_EDIT_TOOLS = [
   'ピクセル消去',
   '丸オブジェクト配置',
   '丸オブジェクト消去',
-  '任意オブジェクト配置',
-  '任意オブジェクト消去',
   'テキストボックス追加',
-  'テキストボックス消去',
-  '直線描画',
-  '直線消去'
+  'テキストボックス消去'
 ] as const
 
 /**
@@ -36,8 +32,6 @@ export type PixelTool = typeof PIXEL_TOOLS[number]
 export const OBJECT_TOOLS = [
   VENUE_EDIT_TOOLS[2], // 丸オブジェクト配置
   VENUE_EDIT_TOOLS[3], // 丸オブジェクト消去
-  VENUE_EDIT_TOOLS[4], // 任意オブジェクト配置
-  VENUE_EDIT_TOOLS[5], // 任意オブジェクト消去
 ] as const
 export type ObjectTool = typeof OBJECT_TOOLS[number]
 
@@ -45,19 +39,10 @@ export type ObjectTool = typeof OBJECT_TOOLS[number]
  * テキスト操作系のツール
  */
 export const TEXT_TOOLS = [
-  VENUE_EDIT_TOOLS[6], // テキストボックス追加
-  VENUE_EDIT_TOOLS[7], // テキストボックス消去
+  VENUE_EDIT_TOOLS[4], // テキストボックス追加
+  VENUE_EDIT_TOOLS[5], // テキストボックス消去
 ] as const
 export type TextTool = typeof TEXT_TOOLS[number]
-
-/**
- * 線操作系のツール
- */
-export const LINE_TOOLS = [
-  VENUE_EDIT_TOOLS[8], // 直線描画
-  VENUE_EDIT_TOOLS[9], // 直線消去
-] as const
-export type LineTool = typeof LINE_TOOLS[number] 
 
 /**
  * 描画可能なツールのリスト
@@ -65,5 +50,9 @@ export type LineTool = typeof LINE_TOOLS[number]
 export const DRAWABLE_TOOLS = [
   PIXEL_TOOLS[0], // ピクセル塗りつぶし
   PIXEL_TOOLS[1], // ピクセル消去
+  OBJECT_TOOLS[0], // 丸オブジェクト配置
+  OBJECT_TOOLS[1], // 丸オブジェクト消去
+  TEXT_TOOLS[0], // テキストボックス追加
+  TEXT_TOOLS[1], // テキストボックス消去
 ] as const
 export type DrawableTool = typeof DRAWABLE_TOOLS[number]


### PR DESCRIPTION
余分なツールの削除を行いました。
それに伴いレイアウトが若干変わっています。

<img width="1270" alt="image" src="https://github.com/user-attachments/assets/11594cb1-f2d2-4641-9915-2128390cf2ac" />


- このイテレーションで実装できなかったツールを定数から削除
- ツール数の減少に伴い間取り編集画面のレイアウトを変更
- 一部のコメントの入れ忘れに対応