### PR TITLE
【イベント】【イベント編集】admin権限でなければ、エラーページを表示させる&ユーザグループの編集を抑制する #186

### DIFF
--- a/front/src/actions/event/eventedit/updateEventInfo.ts
+++ b/front/src/actions/event/eventedit/updateEventInfo.ts
@@ -19,9 +19,6 @@ const BaseSchema = z.object({
   description: z.string({
     required_error: 'イベントの説明は必須です。',
   }),
-  userGroupId: z.coerce.number({
-    required_error: 'ユーザーグループは必須です。',
-  }),
   eventDate: z.string()
     .regex(DATE_PATTERN, 'イベント日はYYYY-MM-DD形式で入力してください。')
     .refine((date) => !isNaN(Date.parse(date)), '有効な日付を入力してください。'),
@@ -88,7 +85,6 @@ export async function updateEventInfo(
   const baseValidation = BaseSchema.safeParse({
     name: formData.get('name'),
     description: formData.get('description'),
-    userGroupId: formData.get('userGroupId'),
     eventDate: formData.get('eventDate'),
     eventStartTime: formData.get('eventStartTime'),
     eventEndTime: formData.get('eventEndTime'),

--- a/front/src/actions/event/eventedit/viewmodel.ts
+++ b/front/src/actions/event/eventedit/viewmodel.ts
@@ -1,6 +1,6 @@
-import { selectEventById } from "@/lib/db/event";
-import { selectUserGroupById } from "@/lib/db/user_group";
-import { formatDateTimeHHMM, formatDateTimeYYYYMMDD_HYPHEN, formatDateTimeYYYYMMDD_SLASH } from "@/lib/util/date";
+import { auth } from "@/lib/auth/auth";
+import { selectEventEditViewInfoByUserEmailAndEventId } from "@/lib/db/event";
+import { formatDateTimeHHMM, formatDateTimeYYYYMMDD_HYPHEN } from "@/lib/util/date";
 import { EventEditViewModel } from "@/types/event/viewmodel";
 
 /**
@@ -10,31 +10,30 @@ import { EventEditViewModel } from "@/types/event/viewmodel";
  * @returns イベント詳細のビューモデル
  */
 export async function getEventEditViewModel(eventId: number): Promise<EventEditViewModel | null> {
-  // イベントを取得
-  const event = await selectEventById(eventId);
-  
-  // イベントが見つからない場合はエラーを返す
-  if (!event) {
+
+  // いつもの認証処理、メールアドレスがなければnullを返す
+  const session = await auth();
+  if (!session?.user?.email) {
     return null;
   }
 
-  // ユーザーグループを取得
-  const userGroup = await selectUserGroupById(event.userGroupId);
-  if (!userGroup) {
+  // イベント編集画面で使うビュー情報を取得
+  const eventEditViewInfo = await selectEventEditViewInfoByUserEmailAndEventId(session.user.email, eventId);
+
+  // ビュー情報がない場合はnullを返す
+  if (!eventEditViewInfo) {
     return null;
   }
 
-  // イベント詳細ビューモデルを作成
+  // イベント編集ビューモデルを作成
   return {
-    eventId: event.id,
-    eventName: event.name,
-    description: event.description ?? '',
-    userGroupId: event.userGroupId, 
-    userGroupName: userGroup.name,
-    eventDate: formatDateTimeYYYYMMDD_HYPHEN(event.startDateTime),
-    eventStartTime: formatDateTimeHHMM(event.startDateTime),
-    eventEndTime: formatDateTimeHHMM(event.endDateTime),
-    eventUrl: event.eventUrl ?? undefined,
-    venueUrl: event.venueUrl ?? undefined,
+    eventId: eventEditViewInfo.id,
+    eventName: eventEditViewInfo.name,
+    description: eventEditViewInfo?.description ?? '',
+    eventDate: formatDateTimeYYYYMMDD_HYPHEN(eventEditViewInfo.startDateTime),
+    eventStartTime: formatDateTimeHHMM(eventEditViewInfo.startDateTime),
+    eventEndTime: formatDateTimeHHMM(eventEditViewInfo.endDateTime),
+    eventUrl: eventEditViewInfo?.eventUrl ?? undefined,
+    venueUrl: eventEditViewInfo?.venueUrl ?? undefined,
   };
 }

--- a/front/src/components/templates/event/eventedit/EventEditTemplate.tsx
+++ b/front/src/components/templates/event/eventedit/EventEditTemplate.tsx
@@ -27,22 +27,13 @@ export default function EventEditTemplate({ eventViewModel }: Readonly<EventEdit
           eventEndTime, 
           eventUrl, 
           venueUrl, 
-          userGroupName, 
-          userGroupId } = eventViewModel;
+       } = eventViewModel;
   
   // オプションの値を代入する
   const [formFields] = useState<EventRegisterFormField[]>(
     EVENT_EDIT_FORM_FIELDS.map((field) => {
       switch (field?.name) {
-        case 'userGroupId':
-          return {
-            ...field,
-            defaultValue: userGroupId.toString(),
-            options: [{
-              value: userGroupId.toString(),
-              label: userGroupName  
-            }]
-          }
+        
         case 'name':
           return {
             ...field,

--- a/front/src/lib/db/event.ts
+++ b/front/src/lib/db/event.ts
@@ -1,7 +1,7 @@
 import { db } from "@/lib/db";
 import { events } from "@/lib/db/schema/event";
-import { asc, eq} from "drizzle-orm";
-import { Event, EventSearchResult, EventWithoutVenueJson, NewEvent, UpdateEvent } from "@/types/event/schema";
+import { asc, eq, and } from "drizzle-orm";
+import { Event, EventSearchResult, EventWithoutVenueJson, NewEvent, UpdateEvent, EventEditViewInfo } from "@/types/event/schema";
 import { users } from "@/lib/db/schema/user";
 import { userGroupAssignments } from "@/lib/db/schema/user_group_assignment";
 import { Transaction } from "@/types/db";
@@ -119,4 +119,33 @@ export async function selectEventsSearchResultByUserEmail(email: string): Promis
     .orderBy(asc(events.startDateTime));
   
   return result;
+}
+
+
+/**
+ * ユーザーのメールアドレスとイベントIDに基づいて、イベント編集画面で使うビュー情報を取得する
+ * 
+ * @param email ユーザーのメールアドレス
+ * @param eventId イベントID
+ * @returns イベント詳細画面で使うビュー情報
+ */
+export async function selectEventEditViewInfoByUserEmailAndEventId(email: string, eventId: number): Promise<EventEditViewInfo | null> {
+  const result = await db
+    .select({
+      id: events.id,
+      name: events.name,
+      description: events.description,
+      startDateTime: events.startDateTime,
+      endDateTime: events.endDateTime,
+      eventUrl: events.eventUrl,
+      venueUrl: events.venueUrl,
+    })
+    .from(events)
+    .innerJoin(userGroupAssignments, eq(events.userGroupId, userGroupAssignments.userGroupId))
+    .innerJoin(users, eq(userGroupAssignments.userId, users.id))
+    .innerJoin(userGroups,eq(userGroupAssignments.userGroupId, userGroups.id) )
+    .where(and(eq(events.id, eventId), eq(users.email, email), eq(userGroupAssignments.role, 'admin')))
+    .limit(1);
+  
+  return result[0] ?? null;
 }

--- a/front/src/lib/event/eventedit/constants.ts
+++ b/front/src/lib/event/eventedit/constants.ts
@@ -84,13 +84,6 @@ export const EVENT_EDIT_FORM_FIELDS: EventRegisterFormField[] = [
     placeholder: 'イベントの概要を入力してください'
   },
   {
-    name: 'userGroupId',
-    label: 'イベントグループ',
-    required: true,
-    elementType: 'select',
-    placeholder: 'イベントグループを選択してください'
-  },
-  {
     name: 'eventDate',
     label: 'イベント日',
     required: true,

--- a/front/src/types/event/schema.ts
+++ b/front/src/types/event/schema.ts
@@ -31,9 +31,9 @@ export type EventSearchResult = {
 };
 
 /**
- * イベント詳細表示用の型
+ * イベント編集画面で使うビューをとってくる時のスキーマの型
  * 
- * イベントの詳細情報を表示する際に使用
+ * イベント編集画面で使うビューを取得する際に使用
  */
 export type EventEditViewInfo = {
   id: number;

--- a/front/src/types/event/schema.ts
+++ b/front/src/types/event/schema.ts
@@ -29,3 +29,18 @@ export type EventSearchResult = {
   userGroupName: string;
   role: Role;
 };
+
+/**
+ * イベント詳細表示用の型
+ * 
+ * イベントの詳細情報を表示する際に使用
+ */
+export type EventEditViewInfo = {
+  id: number;
+  name: string;
+  description: string | null;
+  startDateTime: Date;
+  endDateTime: Date;
+  eventUrl: string | null;
+  venueUrl: string | null;
+};

--- a/front/src/types/event/viewmodel.ts
+++ b/front/src/types/event/viewmodel.ts
@@ -38,8 +38,6 @@ export type EventVenueEditViewModel = {
 export type EventEditViewModel = {
   eventId: number;
   eventName: string;
-  userGroupId: number;
-  userGroupName: string;
   description: string;
   eventDate: string;
   eventStartTime: string;


### PR DESCRIPTION
イベント編集において、権限設定を意識しました。
また、他のレコードに影響を与える可能性があるので、ユーザグループの編集は完全にできないようにしました。