### PR TITLE
【イベント】【間取り編集】サブメニューで選択する際に、選択されているツールをわかりやすくする #194

### DIFF
--- a/front/src/components/organisms/event/venueedit/tools/ToolButtonGroup.tsx
+++ b/front/src/components/organisms/event/venueedit/tools/ToolButtonGroup.tsx
@@ -1,25 +1,35 @@
-import { EDITOR_TOOL_PAIR_TREE, EditorToolPairKey } from '@/types/tool'
+import { EDITOR_TOOL_PAIR_TREE, EditorToolPairKey, VenueEditTool } from '@/types/tool'
 import MonoClomeButton from '@/components/atoms/button/MonoClomeButton'
+import { useCallback } from 'react'
 
 interface ToolButtonGroupProps {
+  selectedTool: VenueEditTool
   setDrawToolFromToolKey: (toolKey: keyof typeof EDITOR_TOOL_PAIR_TREE) => void
 }
 
 /**
  * ツールボタングループ
  * 
- * @param onToolSelect ツール選択時のコールバック
+ * @param selectedTool 現在選択されているツール
+ * @param setDrawToolFromToolKey ツール選択時のコールバック
  * @returns ツールボタングループ
  */
-export default function ToolButtonGroup({ setDrawToolFromToolKey }: Readonly<ToolButtonGroupProps>) {
+export default function ToolButtonGroup({ selectedTool, setDrawToolFromToolKey }: Readonly<ToolButtonGroupProps>) {
+  
+  // 現在選択されているツールがどのツールタイプに属するかを求める関数
+  const isSelected = useCallback((toolKey: EditorToolPairKey) => {
+    return selectedTool === EDITOR_TOOL_PAIR_TREE[toolKey].erase || selectedTool === EDITOR_TOOL_PAIR_TREE[toolKey].generate
+  }, [selectedTool])
+
+  // ツールボタングループ
   return (
     <div className="grid grid-cols-3 xl:grid-cols-1 gap-2 justify-center">
       {Object.entries(EDITOR_TOOL_PAIR_TREE).map(([toolKey, toolPair]) => (
         <MonoClomeButton 
           key={toolKey}  
           onClick={() => setDrawToolFromToolKey(toolKey as EditorToolPairKey)}
-          className="col-span-1 grid grid-cols-1 gap-2"
-          >
+          className={`col-span-1 grid grid-cols-1 gap-2 ${isSelected(toolKey as EditorToolPairKey) ? "bg-blue-800" : ""}`}
+        >
           {toolPair.name}
         </MonoClomeButton>
       ))}

--- a/front/src/components/templates/event/venueedit/VenueEditor.tsx
+++ b/front/src/components/templates/event/venueedit/VenueEditor.tsx
@@ -6,7 +6,6 @@ import { CANVAS_BASE } from '@/lib/event/venueedit/constants'
 interface VenueEditorProps {
   zoom: number
   canvasRef: React.RefObject<HTMLCanvasElement | null>
-  canDraw: () => boolean
   handleMouseDown: (e: React.MouseEvent<HTMLCanvasElement>) => void
   handleMouseMove: (e: React.MouseEvent<HTMLCanvasElement>) => void
   handleMouseUp: () => void
@@ -29,7 +28,6 @@ const canvasStyleFactory = (zoom: number, CANVAS_BASE: number) : React.CSSProper
 export default function VenueEditor({ 
   zoom,
   canvasRef,
-  canDraw,
   handleMouseDown,
   handleMouseMove,
   handleMouseUp,
@@ -54,7 +52,7 @@ export default function VenueEditor({
             style={{
               width: `${CANVAS_BASE}px`,
               height: `${CANVAS_BASE}px`,
-              cursor: canDraw() ? 'crosshair' : 'default'
+              cursor: 'crosshair'
             }}
           />
         </div>

--- a/front/src/components/templates/event/venueedit/VenueEditorTemplate.tsx
+++ b/front/src/components/templates/event/venueedit/VenueEditorTemplate.tsx
@@ -39,7 +39,6 @@ export default function VenueEditorTemplate({ eventVenueEditViewModel }: Readonl
 
   const {
     canvasRef,
-    canDraw,
     zoom,
     numPixel,
     setNumPixel,
@@ -78,7 +77,6 @@ export default function VenueEditorTemplate({ eventVenueEditViewModel }: Readonl
             <VenueEditor 
               zoom={zoom}
               canvasRef={canvasRef}
-              canDraw={canDraw}
               handleMouseDown={handleMouseDown}
               handleMouseMove={handleMouseMove}
               handleMouseUp={handleMouseUp}
@@ -107,6 +105,7 @@ export default function VenueEditorTemplate({ eventVenueEditViewModel }: Readonl
           </div>
           <div className="col-span-1 md:col-span-1 lg:col-span-8 xl:col-span-2">
             <VenueToolSelectionMenu 
+              selectedTool={selectedTool} 
               setDrawToolFromToolKey={setDrawToolFromToolKey}
             />
           </div>

--- a/front/src/components/templates/event/venueedit/VenueToolSelectionMenu.tsx
+++ b/front/src/components/templates/event/venueedit/VenueToolSelectionMenu.tsx
@@ -1,17 +1,25 @@
 import React from 'react'
-import {EditorToolPairKey } from '@/types/tool'
+import {EditorToolPairKey, VenueEditTool } from '@/types/tool'
 import ToolButtonGroup from '@/components/organisms/event/venueedit/tools/ToolButtonGroup'
 
 interface VenueToolSelectionMenuProps {
+  selectedTool: VenueEditTool
   setDrawToolFromToolKey: (toolKey: EditorToolPairKey) => void
 }
 
-export default function VenueToolSelectionMenu({ setDrawToolFromToolKey }: Readonly<VenueToolSelectionMenuProps>) {
+/**
+ * ツール選択メニュー
+ * 
+ * @param selectedTool 現在選択されているツール
+ * @param setDrawToolFromToolKey ツール選択時のコールバック
+ * @returns ツール選択メニュー
+ */
+export default function VenueToolSelectionMenu({ selectedTool, setDrawToolFromToolKey }: Readonly<VenueToolSelectionMenuProps>) {
   return (
     <div className="h-full w-full flex flex-col justify-center items-center border border-gray-900 rounded-lg">
       <div className="h-full w-full flex flex-col">
         <div className="flex-1 overflow-y-auto p-4">
-          <ToolButtonGroup setDrawToolFromToolKey={setDrawToolFromToolKey} />
+          <ToolButtonGroup selectedTool={selectedTool} setDrawToolFromToolKey={setDrawToolFromToolKey} />
         </div>
       </div>
     </div>

--- a/front/src/hooks/event/venueedit/tool/useToolSelect.ts
+++ b/front/src/hooks/event/venueedit/tool/useToolSelect.ts
@@ -52,11 +52,6 @@ export const useToolSelect = ({
   endDrawing,
 }: Props) => {
 
-
-  const canDraw = useCallback(() => {
-    return DRAWABLE_TOOLS.includes(selectedTool as DrawableTool)
-  }, [selectedTool])
-
   const pixelDraw = usePixelDraw({
     canvasRef,
     numPixel,
@@ -153,7 +148,6 @@ export const useToolSelect = ({
   const handleMouseLeave = createHandler('handleMouseLeave')
 
   return {
-    canDraw,
     handleMouseDown,
     handleMouseMove,
     handleMouseUp,

--- a/front/src/hooks/event/venueedit/useCanvasDraw.ts
+++ b/front/src/hooks/event/venueedit/useCanvasDraw.ts
@@ -67,7 +67,7 @@ export const useCanvasDraw = ({
     eventId: eventVenueEditViewModel.eventId
   })
 
-  const { canDraw: toolCanDraw,
+  const {
       handleMouseDown,
       handleMouseMove,
       handleMouseUp,
@@ -98,7 +98,6 @@ export const useCanvasDraw = ({
 
   return { 
     canvasRef, 
-    canDraw: toolCanDraw,
     zoom,
     numPixel,
     handleZoomIn,


### PR DESCRIPTION
ツール選択メニューにおいて、選択中のツールに対応するボタンを青く光らせる対応を行いました。

<img width="1448" alt="image" src="https://github.com/user-attachments/assets/5cccbd93-4559-4cd0-99ea-d561aec5fa34" />


- ツールが選択されている場合に、選択しているツールが青くなるように調整
- canDraw関数の必要性が見えなかったんで除去
- ToolButtonGroupにコメントを追加