### PR TITLE
【共通】プルリクを出した段階でnpm buildができることを確認する(GitHub Action) #232

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -1,0 +1,45 @@
+# ワークフローの名前
+name: Pull Request Build Check
+
+# ワークフローがトリガーされるイベント
+on:
+  # プルリクエストが開かれたとき、同期されたとき、または再オープンされたときにトリガー
+  pull_request:
+    # どのブランチに対してプルリクエストが出されたときに実行するか
+    branches:
+      - main # 必要に応じて、対象ブランチをカンマ区切りで追加してください (例: main, develop)
+
+# ワークフローで実行されるジョブ
+jobs:
+  # ビルドチェックのジョブ
+  build:
+    # ジョブが実行されるVM環境
+    runs-on: ubuntu-latest # 最新のUbuntu環境を使用
+
+    # ジョブのステップ
+    steps:
+      # 1. リポジトリのコードをチェックアウト
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      # 2. Node.js環境のセットアップ
+      # プロジェクトに必要なNode.jsのバージョンを指定します。
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20' #
+          cache: 'npm' 
+          cache-dependency-path: ./front/package-lock.json
+
+      # 3. 依存関係のインストール
+      # CI/CD環境では、npm ci を使用することが推奨されます。
+      # これは package-lock.json を基に正確な依存関係をインストールし、より信頼性の高いビルドを保証します。
+      - name: Install Dependencies
+        run: npm ci
+        working-directory: ./front
+
+      # 4. プロジェクトのビルド
+      # package.jsonで定義されている 'build' スクリプトを実行します。
+      - name: Run Build
+        run: npm run build
+        working-directory: ./front

--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
     # どのブランチに対してプルリクエストが出されたときに実行するか
     branches:
-      - main # 必要に応じて、対象ブランチをカンマ区切りで追加してください (例: main, develop)
+      - develop
 
 # ワークフローで実行されるジョブ
 jobs:

--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           node-version: '20' #
           cache: 'npm' 
-          cache-dependency-path: ./front/package-lock.json
+          cache-dependency-path: front/package-lock.json
 
       # 3. 依存関係のインストール
       # CI/CD環境では、npm ci を使用することが推奨されます。

--- a/front/src/app/(withsidebar)/sample/list/queryserver/page.tsx
+++ b/front/src/app/(withsidebar)/sample/list/queryserver/page.tsx
@@ -4,7 +4,7 @@ import { getEventListViewModelServerPagenationSample } from "@/actions/sample/li
 export default async function Events({
   searchParams,
 }: {
-  searchParams: { [key: string]: string | string[] | undefined }
+  searchParams: Promise<{ [key: string]: string | string[] | undefined }>
 }) {
   const params = await searchParams;
   const {events, totalCount, currentPage, totalPages, pageSize} = await getEventListViewModelServerPagenationSample({


### PR DESCRIPTION
GitHub Actionsワークフローを構築し、プルリクを投げた段階でビルドが走るかどうかをチェックできるようにしました。

本番リリース前にbuildを直すのは億劫なので、
以降は、ビルドできることを確認してからマージするようにしてください。