### PR TITLE
【イベント】【詳細】admin権限でなければ、編集できないようにする&コピーボタンの削除 #220

### DIFF
--- a/front/src/actions/event/eventview/viewmodel.ts
+++ b/front/src/actions/event/eventview/viewmodel.ts
@@ -1,7 +1,8 @@
-import { selectEventById } from "@/lib/db/event";
+import { checkUserIsAdminOfEventByUserEmailAndEventId, selectEventById } from "@/lib/db/event";
 import { selectUserGroupById } from "@/lib/db/user_group";
 import { EventViewViewModel } from "@/types/event/viewmodel";
 import { formatDateTimeYYYYMMDDHHMMJPN } from "@/lib/util/date";
+import { auth } from "@/lib/auth/auth";
 
 /**
  * イベントIDからイベント詳細ビューモデルを取得
@@ -13,16 +14,25 @@ export async function getEventViewViewModel(eventId: number): Promise<EventViewV
   // イベントを取得
   const event = await selectEventById(eventId);
   
-  // イベントが見つからない場合はエラーを返す
+  // イベントが見つからない場合はnullを返す
   if (!event) {
     return null;
   }
 
-  // ユーザーグループを取得
+  // ユーザーグループを取得、できなければnullを返す
   const userGroup = await selectUserGroupById(event.userGroupId);
   if (!userGroup) {
     return null;
   }
+
+  // いつもの認証処理、メールアドレスがなければnullを返す
+  const session = await auth();
+  if (!session?.user?.email) {
+    return null;
+  }
+  
+  // ユーザーがイベントの管理者であるかを確認する
+  const isAdmin = await checkUserIsAdminOfEventByUserEmailAndEventId(session.user.email, event.id);
 
   // イベント詳細ビューモデルを作成
   return {
@@ -35,7 +45,8 @@ export async function getEventViewViewModel(eventId: number): Promise<EventViewV
     eventUrl: event.eventUrl ?? undefined,
     venueUrl: event.venueUrl ?? undefined,
     userGroupName: userGroup.name,
-    userGroupUrl: `/user_group/${userGroup.id}`,
-    imageUrl: event.imageUrl ?? undefined
+    userGroupUrl: `/user_group/view/${userGroup.id}`,
+    imageUrl: event.imageUrl ?? undefined,
+    isAdmin: isAdmin,
   };
 }

--- a/front/src/components/templates/event/view/EventView.tsx
+++ b/front/src/components/templates/event/view/EventView.tsx
@@ -26,20 +26,15 @@ export default function EventView({ event }: Readonly<Props>) {
   return (
     <div className={eventContainerClass}>
       <div className="flex justify-end items-center w-full gap-x-2">
-        <ViewIconUnit unit={{
-          name: "edit",
-          iconName: "Pencil",
-          description: "編集",
-          href: `/event/eventedit/${event.eventId}`,
-          iconClassName: "w-6 h-6",
-        }} />
-        <ViewIconUnit unit={{
-          name: "copy",
-          iconName: "Copy",
-          description: "イベントコピー",
-          iconClassName: "w-6 h-6",
-          onClick: async () => {},
-        }} />
+        {event.isAdmin && (
+          <ViewIconUnit unit={{
+            name: "edit",
+            iconName: "Pencil",
+            description: "編集",
+            href: `/event/eventedit/${event.eventId}`,
+            iconClassName: "w-6 h-6",
+          }} />
+        )}
       </div>
       <CommonViewIconUnitList units={eventViewIconUnits} />
     </div>

--- a/front/src/components/templates/event/view/VenueView.tsx
+++ b/front/src/components/templates/event/view/VenueView.tsx
@@ -20,13 +20,15 @@ export default function VenueView({ event }: Readonly<Props>) {
   return (
     <div className={eventContainerClass}>
       <div className="flex justify-end items-center w-full gap-x-2">
-      <ViewIconUnit unit={{
-          name: "venueEdit",
-          iconName: "Pencil",
-          description: "編集",
-          href: `/event/venueedit/${event.eventId}`,
-          iconClassName: "w-6 h-6",
-        }} />
+        {event.isAdmin && (
+          <ViewIconUnit unit={{
+            name: "venueEdit",
+            iconName: "Pencil",
+            description: "編集",
+            href: `/event/venueedit/${event.eventId}`,
+            iconClassName: "w-6 h-6",
+          }} />
+        )}
       </div>
       <div className="flex justify-center items-center mx-2 rounded-lg h-full">
         {event.imageUrl ? (

--- a/front/src/lib/db/event.ts
+++ b/front/src/lib/db/event.ts
@@ -216,3 +216,25 @@ export async function selectEventEditViewInfoByUserEmailAndEventId(email: string
   }
   return null;
 }
+
+/**
+ * ユーザーのメールアドレスとイベントIDに基づいて、ユーザーがイベントの管理者であるかを確認する
+ * 
+ * @param email ユーザーのメールアドレス
+ * @param eventId イベントID
+ * @returns ユーザーがイベントの管理者であるかどうか
+ */
+export async function checkUserIsAdminOfEventByUserEmailAndEventId(email: string, eventId: number): Promise<boolean> {
+  const result = await db
+    .select({
+      role: userGroupAssignments.role,
+    })
+    .from(events)
+    .innerJoin(userGroupAssignments, eq(events.userGroupId, userGroupAssignments.userGroupId))
+    .innerJoin(users, eq(userGroupAssignments.userId, users.id))
+    .innerJoin(userGroups,eq(userGroupAssignments.userGroupId, userGroups.id) )
+    .where(and(eq(events.id, eventId), eq(users.email, email), eq(userGroupAssignments.role, 'admin')))
+    .limit(1);
+  
+  return result.length > 0;
+}

--- a/front/src/types/event/viewmodel.ts
+++ b/front/src/types/event/viewmodel.ts
@@ -17,6 +17,7 @@ export type EventViewViewModel = {
   userGroupName: string;
   userGroupUrl: string;
   imageUrl?: string;
+  isAdmin: boolean;
 };
 
 /**


### PR DESCRIPTION
（コンフリクトしてたのでやり直し）
イベント詳細についても同様に、admin権限がなければ編集できないようにしました。
ついでにコピーボタンも削除しています。