### PR TITLE
【イベント】イベント新規作成or編集時の日付選択をDatePickerコンポーネントに置き換える #250

### DIFF
--- a/front/src/components/molecules/field/FormInputDate.tsx
+++ b/front/src/components/molecules/field/FormInputDate.tsx
@@ -30,7 +30,8 @@ interface FormInputDateProps {
  */
 export default function FormInputDate({ name, placeholder, hasError, defaultValue }: Readonly<FormInputDateProps>) {
   // 日付を管理するstate(デフォルト値があればそれを使用し、なければ今日の日付を使用)
-  const [date, setDate] = useState<Date>(defaultValue ? new Date(defaultValue) : new Date())
+  const [date, setDate] = useState<Date>(defaultValue ? 
+          getDateTimeRemovedTimezone(new Date(defaultValue)) : getDateTimeRemovedTimezone(new Date()))
   
   return (
     <> 

--- a/front/src/components/molecules/field/FormInputDate.tsx
+++ b/front/src/components/molecules/field/FormInputDate.tsx
@@ -48,7 +48,7 @@ export default function FormInputDate({ name, placeholder, hasError, defaultValu
       <input
         type="hidden"
         name={name}
-        placeholder={placeholder}
+        
         value={formatDateTimeYYYYMMDD_HYPHEN(date)}
       />
     </>

--- a/front/src/components/molecules/field/FormInputDate.tsx
+++ b/front/src/components/molecules/field/FormInputDate.tsx
@@ -1,0 +1,55 @@
+import { DatePicker } from "@/components/molecules/input/DatePicker"
+import { useState } from "react";
+import { cn } from "@/lib/shadcn/utils";
+import { formatDateTimeYYYYMMDD_HYPHEN, getDateTimeRemovedTimezone } from "@/lib/util/date";
+
+interface FormInputDateProps {
+  name: string;
+  placeholder?: string;
+  hasError?: boolean;
+  defaultValue?: string;
+}
+
+/**
+ * フォームの入力フィールドコンポーネント
+ * 
+ * @param name - 入力フィールドの名前（必須）
+ * @param placeholder - プレースホルダーテキスト
+ * @param hasError - エラー状態かどうか
+ * @param defaultValue - デフォルト値
+ * 
+ * @example
+ * ```tsx
+ * <FormInputDate
+ *   name="date"
+ *   placeholder="日付を入力"
+ *   hasError={errors.date}
+ *   defaultValue={formData.date}
+ * />
+ * ```
+ */
+export default function FormInputDate({ name, placeholder, hasError, defaultValue }: Readonly<FormInputDateProps>) {
+  // 日付を管理するstate(デフォルト値があればそれを使用し、なければ今日の日付を使用)
+  const [date, setDate] = useState<Date>(defaultValue ? new Date(defaultValue) : new Date())
+  
+  return (
+    <> 
+      <DatePicker
+        className={cn('w-full p-2 rounded-md text-md', hasError ? 'border-red-500' : 'border-gray-300')}
+        value={date}
+        onChange={(date) => {
+          if (date) {
+            setDate(getDateTimeRemovedTimezone(date))
+          }
+        }}
+        placeholder={placeholder}
+      />
+      <input
+        type="hidden"
+        name={name}
+        placeholder={placeholder}
+        value={formatDateTimeYYYYMMDD_HYPHEN(date)}
+      />
+    </>
+  );
+} 

--- a/front/src/components/organisms/common/form/FormField.tsx
+++ b/front/src/components/organisms/common/form/FormField.tsx
@@ -2,6 +2,7 @@ import { CommonRegisterFormField } from '@/types/common/form';
 import FormInput from '@/components/molecules/field/FormInput';
 import FormTextarea from '@/components/molecules/field/FormTextarea';
 import FormSelect from '@/components/molecules/field/FormSelect';
+import FormInputDate from '@/components/molecules/field/FormInputDate';
 
 interface FormFieldProps<T> {
   field: CommonRegisterFormField<T>;
@@ -32,6 +33,8 @@ interface FormFieldProps<T> {
  * ```
  */
 export default function FormField<T>({ field, hasError, defaultValue }: Readonly<FormFieldProps<T>>) {
+  
+  // テキストエリアの場合
   if (field.elementType === 'textarea') {
     return (
       <FormTextarea
@@ -44,6 +47,7 @@ export default function FormField<T>({ field, hasError, defaultValue }: Readonly
     );
   }
 
+  // セレクトボックスの場合
   if (field.elementType === 'select') {
     return (
       <FormSelect
@@ -56,7 +60,19 @@ export default function FormField<T>({ field, hasError, defaultValue }: Readonly
       />
     );
   }
+  // 日付入力フィールドの場合
+  if (field.elementType === 'input' && field.inputType === 'date') {
+    return (
+      <FormInputDate
+        name={field.name.toString()}
+        placeholder={field.placeholder}
+        hasError={hasError}
+        defaultValue={defaultValue}
+      />
+    );
+  }
 
+  // その他のフィールドの場合
   return (
     <FormInput
       name={field.name.toString()}

--- a/front/src/lib/util/date.ts
+++ b/front/src/lib/util/date.ts
@@ -181,3 +181,12 @@ export function getCurrentDateInLocalTimezone(): Date {
 export function getCurrentDateInTokyo(): Date {
   return toZonedTime(new Date(), 'Asia/Tokyo');
 }
+
+/**
+ * タイムゾーンを削除した日時を取得する関数
+ * @param date タイムゾーンを削除したい日時
+ * @returns タイムゾーンを削除した日時
+ */
+export function getDateTimeRemovedTimezone(date: Date): Date {
+  return new Date(date.getTime() - date.getTimezoneOffset() * 60000);
+}


### PR DESCRIPTION
ご無沙汰しております。

イベント作成or 編集時の日付選択の際に、専用のコンポーネントを利用するように修正しました。
これにより、ブラウザの標準仕様ではなく、専用のUIで日付の選択ができるようになります。
その他、一部修正を行なっています。

以下、修正の概要です。
- Form要素で使える日付選択用のコンポーネント(FormInputDate)を実装
- lib/utilにgetDateTimeRemovedTimezoneを追加
- CommonRegisterFormFieldでinput要素かつ、typeがdateである場合に、今回追加したコンポーネントを使用するように変更
- FormField.tsxにコメントを追加

以下、イベント新規作成機能における差分となります。

前：
<img width="537" height="878" alt="image" src="https://github.com/user-attachments/assets/ef300c99-44e3-4c39-a7cf-8f78546addd3" />


後：
<img width="475" height="833" alt="image" src="https://github.com/user-attachments/assets/f7385467-cc58-4a36-8638-b17a31e829ab" />

