### PR TITLE
【共通】【Form用汎用コンポーネント】Selectするフィールド用のコンポーネントを実装 #254

### DIFF
--- a/front/src/components/atoms/shadcn/select.tsx
+++ b/front/src/components/atoms/shadcn/select.tsx
@@ -44,7 +44,7 @@ function SelectTrigger({
     >
       {children}
       <SelectPrimitive.Icon asChild>
-        <ChevronDownIcon className="size-4 opacity-50" />
+        <ChevronDownIcon className="size-4 opacity-100 text-gray-900" />
       </SelectPrimitive.Icon>
     </SelectPrimitive.Trigger>
   )

--- a/front/src/components/molecules/field/FormSelect.tsx
+++ b/front/src/components/molecules/field/FormSelect.tsx
@@ -1,3 +1,13 @@
+import { useState } from "react"
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/atoms/shadcn/select"
+
 interface FormSelectProps {
   name: string;
   placeholder?: string;
@@ -33,24 +43,32 @@ interface FormSelectProps {
  * ```
  */
 export default function FormSelect({ name, placeholder, required, hasError, defaultValue, options }: Readonly<FormSelectProps>) {
+  const [value, setValue] = useState(defaultValue || '');
+
   return (
-    <select
-      name={name}
-      required={required}
-      defaultValue={defaultValue}
-      className={`w-full p-2 border rounded ${hasError ? 'border-red-500' : 'border-gray-300'}`}
-      key={name} // バリデーションエラー後にセレクトボックスの値を残すために使用
-    >
-      {placeholder && (
-        <option value="" disabled>
-          {placeholder}
-        </option>
-      )}
-      {options.map((option) => (
-        <option key={option.value} value={option.value}>
-          {option.label}
-        </option>
-      ))}
-    </select>
+    <>
+      <Select value={value} onValueChange={setValue}>
+        <SelectTrigger 
+          className={`w-full ${hasError ? 'border-red-500' : 'border-gray-300'}`}
+        >
+          <SelectValue placeholder={placeholder} />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectGroup>
+            {options.map((option) => (
+              <SelectItem key={option.value} value={option.value}>
+                {option.label}
+              </SelectItem>
+            ))}
+          </SelectGroup>
+        </SelectContent>
+      </Select>
+      <input 
+        type="hidden" 
+        name={name} 
+        value={value} 
+        required={required}
+      />
+    </>
   );
 } 


### PR DESCRIPTION
汎用Form機能において、select系のフィールドであればがそのまま使われていました。
しかしながら、今のままでは、見た目がブラウザに依存してしまいます。
また、#250 で実装されたものと見た目が微妙に異なるため、若干違和感がありました(@イベント新規登録画面)。

#250適用かつ本修正の適用前(@新規イベント登録)：
<img width="467" height="444" alt="image" src="https://github.com/user-attachments/assets/ec6b07af-009c-4310-a76f-2db51dfba6fa" />


そこで、FormSelect.tsxにおいて、HTML標準をそのまま使うのではなく、shadcnで実装されているSelectをラッピングするように修正しました。

変更後(@新規イベント登録)：

<img width="467" height="452" alt="image" src="https://github.com/user-attachments/assets/bd9829fb-ecf8-413b-97a6-ff03be276967" />