### PR TITLE
【イベント】【新規作成】ユーザグループが空でもイベントを作れてしまう（なお誰もアクセスはできない） #272

### DIFF
--- a/front/src/actions/event/register/viewmodel.ts
+++ b/front/src/actions/event/register/viewmodel.ts
@@ -19,9 +19,9 @@ const BaseSchema = z.object({
   description: z.string({
     required_error: 'イベントの説明は必須です。',
   }),
-  userGroupId: z.coerce.number({
-    required_error: 'ユーザーグループは必須です。',
-  }),
+  userGroupId: z.string()
+    .regex(/^\d+$/, { message: 'ユーザーグループの指定が不正です。' })
+    .transform((val) => Number(val)),
   eventDate: z.string()
     .regex(DATE_PATTERN, 'イベント日はYYYY-MM-DD形式で入力してください。')
     .refine((date) => !isNaN(Date.parse(date)), '有効な日付を入力してください。'),

--- a/front/src/actions/event/register/viewmodel.ts
+++ b/front/src/actions/event/register/viewmodel.ts
@@ -20,8 +20,7 @@ const BaseSchema = z.object({
     required_error: 'イベントの説明は必須です。',
   }),
   userGroupId: z.string()
-    .regex(/^\d+$/, { message: 'ユーザーグループの指定が不正です。' })
-    .transform((val) => Number(val)),
+    .refine((val) => val.length > 0 && !isNaN(Number(val)), { message: 'ユーザーグループの指定が不正です。' }),
   eventDate: z.string()
     .regex(DATE_PATTERN, 'イベント日はYYYY-MM-DD形式で入力してください。')
     .refine((date) => !isNaN(Date.parse(date)), '有効な日付を入力してください。'),
@@ -108,6 +107,7 @@ export async function registerEvent(
     ...rest,
     startDateTime: new Date(`${eventDate}T${eventStartTime}:00.000`),
     endDateTime: new Date(`${eventDate}T${eventEndTime}:00.000`),
+    userGroupId: Number(rest.userGroupId)
   };
 
   // イベントの登録処理(トランザクションは正直なくてもいいけど、lib/db側の記述がシンプルになるために使用)

--- a/front/src/components/templates/event/register/EventRegisterTemplate.tsx
+++ b/front/src/components/templates/event/register/EventRegisterTemplate.tsx
@@ -25,6 +25,7 @@ export default function EventRegisterTemplate({ userGroups }: Readonly<EventRegi
       field?.name === 'userGroupId'
         ? {
             ...field,
+            defaultValue: userGroups[0].id.toString(),
             options: userGroups.map(group => ({
               value: group.id.toString(),
               label: group.name


### PR DESCRIPTION
ユーザグループを入力しなくてもイベントが作れてしまい、かつ、リダイレクト時に404と出てしまうエラーが確認されました。

状況を分析すると以下のことが確認できました。

1. フォーム上のフィールド(user_group)が空欄の状態で渡される
2. バリデーション時にエラーとならず0として解釈
3. userGroupIdが0となり、そんなグループは存在しないので誰もアクセスできない。

よって、以下の対策を実施します。

- 新規グループ作成画面において、デフォルト値としてユーザグループを設定しておく
- バリデーションで弾かれるようにする

手動ではまず起こらないですが、万が一select要素から値が消えてもバリデーションエラーとして処理されます。

<img width="463" height="642" alt="Image" src="https://github.com/user-attachments/assets/09ff11e3-990d-4ed7-9ed2-779d678b5014" />